### PR TITLE
Docs refresh: audit against implementation, per-section code links, verified live examples

### DIFF
--- a/bench/README.md
+++ b/bench/README.md
@@ -271,11 +271,12 @@ the repo root, include the `__mountMs` snippet in its HTML (copy from
 - The page's headline is **geometric-mean slowdown** vs the per-operation fastest framework;
   the table shades cells by that factor. Medians everywhere; hover cells/bars for distributions
   (op cells include GC time in the hover).
-- Reference points from the 2026-07-06 run set (M4 Max, Chromium 149, 13-op suite): Svelte
-  1.02×, vanilla 1.04×, Preact 1.11×, Vue 1.23×, React 1.27×, **Kinetica 1.20×**. Kinetica is
-  ahead of React on create-10k (298 ms vs 316 ms), startup (22.6 ms vs 27.3 ms), and the 1k-row
-  swap case (7.3 ms vs 22.4 ms). The 10k partial ops still drive the remaining gap. On the
-  historical 9-op view only, Kinetica is 1.13× vs React 1.28×.
+- Reference points from the 2026-07-07 run set (M4 Max, Chromium 149, 13-op suite; kinetica +
+  vanilla re-benched after frame ordinals, stored parts for the rest): Svelte 1.03×, vanilla
+  1.04×, Preact 1.12×, Vue 1.24×, React 1.28×, **Kinetica 1.24×** — and **0.969× vs React**
+  head-to-head. Kinetica is ahead of React on create-10k (284 ms vs 316 ms), startup
+  (24.5 ms vs 27.3 ms), and both swap cases (8.1 ms vs 22.5 ms on 1k; 42.1 ms vs 54.1 ms on
+  10k). remove-10k and update-10th-10k still drive the remaining gap.
   Re-run all frameworks before
   comparing headline geomeans across suite changes.
 - Kinetica context: 1k partial ops sit at the paint floor via keyed row memoization; the remaining

--- a/docs/README.md
+++ b/docs/README.md
@@ -18,6 +18,7 @@ server.
 
 ```sh
 cd bench && npm install && cd ..
+./kotlin publish mavenLocal -m kinetica-compiler   # mandatory plugin, resolved via mavenLocal
 node scripts/bundle-docs.mjs
 PORT=8080 ./kotlin run -m docs-site
 open http://127.0.0.1:8080/

--- a/docs/README.md
+++ b/docs/README.md
@@ -48,16 +48,21 @@ created by the script.
 DOCS_BASE_URL=http://127.0.0.1:8080 node docs/verify-docs.mjs
 ```
 
-Checks: all pages server-render, the live counter/keyed-list examples mount and react, the
-resource-fetch demo on `/docs/resources` loads its per-visitor session stack, surfaces the
-backend's intentional `NullPointerException` for "Java" through the error boundary and recovers
-on retry, and the server-components demo hydrates its island, receives the streamed patch, and
-dispatches the typed add-to-cart action.
+Checks: all pages server-render with no source-link comment leaking into the HTML, the live
+counter/keyed-list/effect-timer/form-signup examples mount and react, the resource-fetch demo
+on `/docs/resources` loads its per-visitor session stack, surfaces the backend's intentional
+`NullPointerException` for "Java" through the error boundary and recovers on retry, and the
+server-components demo hydrates its island, receives the streamed patch, and dispatches the
+typed add-to-cart action.
 
 ## Adding a page
 
 1. Write `docs/docs-site/resources/docs/<slug>.md`.
 2. Register the slug in `DocPages` (`docs/docs-site/src/Pages.kt`) — order defines the sidebar.
-3. Embed live examples with a `::: example <name>` line; implement the name in
+3. Link every section to the code it documents with an HTML comment right under the heading:
+   `<!-- code: kinetica-runtime/src/ComponentScope.kt (state, derived) -->`. Comments are
+   skipped by the markdown parser and never render; they keep prose and implementation
+   cross-checkable.
+4. Embed live examples with a `::: example <name>` line; implement the name in
    `docs/docs-client/src/main.kt`.
-4. `node scripts/bundle-docs.mjs && ./kotlin build -m docs-site && PORT=8080 ./kotlin run -m docs-site`.
+5. `node scripts/bundle-docs.mjs && ./kotlin build -m docs-site && PORT=8080 ./kotlin run -m docs-site`.

--- a/docs/docker-build.sh
+++ b/docs/docker-build.sh
@@ -9,6 +9,8 @@ stage="$repo_root/docs/.docker-stage"
 image="${IMAGE:-kinetica-docs}"
 
 cd "$repo_root"
+# The compiler plugin is mandatory for every module and resolves via mavenLocal.
+./kotlin publish mavenLocal -m kinetica-compiler
 ./kotlin package -m docs-site
 node scripts/bundle-docs.mjs
 

--- a/docs/docs-client/module.yaml
+++ b/docs/docs-client/module.yaml
@@ -5,6 +5,7 @@ apply:
 
 dependencies:
   - ../../kinetica-browser
+  - ../../kinetica-forms
   - ../../kinetica-runtime
 
 description: "Client bundle for the documentation site: mounts live interactive examples into doc pages."

--- a/docs/docs-client/src/main.kt
+++ b/docs/docs-client/src/main.kt
@@ -15,6 +15,12 @@ import io.heapy.kinetica.derived
 import io.heapy.kinetica.each
 import io.heapy.kinetica.errorBoundary
 import io.heapy.kinetica.event
+import io.heapy.kinetica.forms.field
+import io.heapy.kinetica.forms.formState
+import io.heapy.kinetica.forms.minLength
+import io.heapy.kinetica.forms.required
+import io.heapy.kinetica.forms.textInput
+import io.heapy.kinetica.forms.validators
 import io.heapy.kinetica.host
 import io.heapy.kinetica.loadingBoundary
 import io.heapy.kinetica.resource
@@ -45,17 +51,29 @@ fun main() {
         val name = container.getAttribute("data-example") ?: continue
         val slot = container.querySelector(".live-example-slot") ?: continue
         slot.textContent = ""
-        val app = mountKineticaApp(slot, KineticaRuntime(debug = false)) {
+        val runtime = KineticaRuntime(debug = false)
+        val app = mountKineticaApp(slot, runtime) {
             when (name) {
                 "counter" -> CounterExample()
                 "keyed-list" -> KeyedListExample()
                 "input-mirror" -> InputMirrorExample()
                 "resource-fetch" -> ResourceFetchExample()
+                "effect-timer" -> EffectTimerExample()
+                "form-signup" -> FormSignupExample()
                 else -> text("Unknown example: $name")
             }
         }
         keepAsyncWorkRendered(container, app)
+        if (name == "effect-timer") {
+            // The stopwatch keeps a watch running between events, so awaitIdle (which waits
+            // for full quiescence) can't pump its ticks — drive them with a coarse interval.
+            scheduleIntervalRender { if (runtime.hasPendingInvalidation) app.render() }
+        }
     }
+}
+
+private fun scheduleIntervalRender(callback: () -> Unit) {
+    js("setInterval(function () { callback(); }, 100)")
 }
 
 /**
@@ -145,6 +163,111 @@ private fun ComponentScope.KeyedListExample() {
         host("p", props = mapOf("class" to "ex-note")) {
             text(
                 "Rows are keyed by id: reversing moves the same DOM elements instead of recreating them.",
+                semantics = null,
+            )
+        }
+    }
+}
+
+@UiComponent
+private fun ComponentScope.EffectTimerExample() {
+    var running by state { false }
+    var ticks by state { 0 }
+
+    watch(source = { running }) { active ->
+        if (active) {
+            while (true) {
+                delay(100)
+                ticks += 1
+            }
+        }
+    }
+
+    host("div", props = mapOf("class" to "ex")) {
+        host("p", props = mapOf("class" to "ex-value")) {
+            text("${ticks / 10}.${ticks % 10}s", semantics = null)
+        }
+        host("div", props = mapOf("class" to "ex-row")) {
+            button(
+                onClick = event { running = !running },
+                semantics = Semantics(role = Role.Button, testTag = "timer-toggle"),
+            ) {
+                text(if (running) "Stop" else "Start", semantics = null)
+            }
+            button(onClick = event { running = false; ticks = 0 }, enabled = ticks != 0) {
+                text("Reset", semantics = null)
+            }
+        }
+        host("p", props = mapOf("class" to "ex-note")) {
+            text(
+                "Start flips one cell; a watch on it loops while it is true. " +
+                    "Stop writes it back — the runtime cancels the previous watch block.",
+                semantics = null,
+            )
+        }
+    }
+}
+
+@UiComponent
+private fun ComponentScope.FormSignupExample() {
+    val form = formState()
+    val email = field(form, "email", initial = { "" }) { value ->
+        validators(required(), minLength(3)).validate(value)
+    }
+    val password = field(form, "password", initial = { "" }) { value ->
+        minLength(8).validate(value)
+    }
+    var submitAttempt by state { 0 }
+    var submitted by state { false }
+
+    watch(source = { submitAttempt }) { attempt ->
+        if (attempt > 0) {
+            submitted = form.submit {
+                delay(150) // a real app would call its API here
+            }
+        }
+    }
+
+    host("div", props = mapOf("class" to "ex")) {
+        textInput(
+            email,
+            placeholder = "Email",
+            semantics = Semantics(role = Role.TextInput, testTag = "signup-email", focusable = true),
+        )
+        textInput(
+            password,
+            placeholder = "Password (8+ characters)",
+            semantics = Semantics(role = Role.TextInput, testTag = "signup-password", focusable = true),
+        )
+        val errors = form.errors()
+        if (errors.isNotEmpty()) {
+            host("ul", props = mapOf("class" to "ex-list")) {
+                each(errors.entries.toList(), key = { it.key }) { (name, message) ->
+                    host("li", props = mapOf("class" to "ex-error"), key = name) {
+                        text("$name: $message", semantics = null)
+                    }
+                }
+            }
+        }
+        host("div", props = mapOf("class" to "ex-row")) {
+            button(
+                onClick = event { submitAttempt += 1 },
+                enabled = !form.isSubmitting,
+                semantics = Semantics(role = Role.Button, testTag = "signup-submit"),
+            ) {
+                text(if (form.isSubmitting) "Signing up…" else "Sign up", semantics = null)
+            }
+            button(onClick = event { form.reset(); submitted = false }, semantics = null) {
+                text("Reset", semantics = null)
+            }
+        }
+        host("p", props = mapOf("class" to "ex-note")) {
+            text(
+                when {
+                    submitted -> "Signed up — every validator passed, so form.submit ran its block."
+                    submitAttempt > 0 -> "Not submitted: fix the errors above and try again."
+                    else -> "A never-validated form is not valid; submit validates every field first."
+                },
                 semantics = null,
             )
         }

--- a/docs/docs-site/resources/docs/browser-renderer.md
+++ b/docs/docs-site/resources/docs/browser-renderer.md
@@ -1,5 +1,7 @@
 # Browser renderer
 
+<!-- code: kinetica-browser/src@js/BrowserKineticaApp.kt (mountKineticaApp, render) -->
+
 `kinetica-browser` is a **retained-mode DOM renderer**. The first render mounts the tree; every
 subsequent render diffs the fresh `Node` value against a mounted shadow tree and applies the
 minimal patch. Rendering a select-row change in a 1,000-row table costs two attribute writes,
@@ -13,19 +15,26 @@ mountKineticaApp("#app", runtime = KineticaRuntime(debug = false)) {
 
 ## What a patch does
 
+<!-- code: kinetica-browser/src@js/BrowserKineticaApp.kt (patch, applyProp, patchKeyedChildren), kinetica-browser/src/ListReconcile.kt (longestIncreasingSubsequenceIndices) -->
+
 - **Reference-equal subtrees are skipped in O(1).** If a subtree's `Node` is the *same object*
   as last render's (memoized [`each` rows](/docs/lists-and-keys), `skippableNode`), the patch
   doesn't descend into it at all.
-- **Props** diff per name: attributes set/removed through the sanitizing allowlist; `value`,
-  `checked`, `disabled` applied as DOM properties (controlled inputs keep cursor and selection —
-  a re-render only writes `input.value` when it actually differs).
-- **Text** updates via `nodeValue` — no element churn.
+- **Props** diff per name: attributes set/removed through the sanitizing allowlist; `value` and
+  `checked` applied as DOM properties (controlled inputs keep cursor and selection —
+  a re-render only writes `input.value` when it actually differs); the `enabled` prop maps to
+  the DOM `disabled` attribute.
+- **Text** updates write the text node in place (`textContent`, or `nodeValue` on the
+  single-text and template fast paths) — no element churn.
 - **Keyed children** reconcile by key: common prefix/suffix patch in place, the middle uses a
   longest-increasing-subsequence plan so reorders become the minimum set of element *moves*.
   Unkeyed lists patch positionally.
-- **Semantics** changes add/remove exactly the affected aria attributes.
+- **Semantics** changes reapply the node's semantics attributes (previous set removed, next set
+  written).
 
 ## Event delegation
+
+<!-- code: kinetica-browser/src@js/BrowserKineticaApp.kt (handleDelegatedEvent, dispatchAndRender, DelegatedEventTypes) -->
 
 Elements carry **no listeners**. One listener set on the app root handles `click`, `input`,
 `change` and `keydown`, resolves the nearest node with a handler, and dispatches into the
@@ -36,11 +45,15 @@ commits before the frame paints.
 
 ## Focus
 
+<!-- code: kinetica-browser/src@js/BrowserKineticaApp.kt (BrowserFocus) -->
+
 Because the DOM is retained, focus and text selection survive re-renders naturally. The renderer
 restores focus only when a patch actually replaced the focused element's subtree — and does so
 with `preventScroll`, so background updates never scroll the page.
 
 ## Debug mode
+
+<!-- code: kinetica-runtime/src/KineticaRuntime.kt (debug, record), kinetica-browser/src@js/BrowserKineticaApp.kt (mountHost, refreshGeneratedAttributes) -->
 
 With `debug = true` (the default for `mountKineticaApp`), elements carry `data-kinetica-tag` /
 `data-kinetica-path` attributes for tooling, duplicate `each` keys throw, and the runtime
@@ -48,11 +61,15 @@ journals every event and patch cause. Production mounts skip all of it.
 
 ## Testing hooks
 
+<!-- code: kinetica-browser/src@js/BrowserKineticaApp.kt (BrowserKineticaApp, BrowserUiSnapshot) -->
+
 `BrowserKineticaApp` exposes `innerHtml()`, `tree()`, `snapshot()` (DOM + tree HTML + tree
 JSON), `elementByTestTag`, `clickTestTag`, `inputTestTag`, and `awaitIdle()` for async
 settling — the browser-level complement to the [headless harness](/docs/testing).
 
 ## History
+
+<!-- code: plan.md (perf stream context), bench/results/results.json -->
 
 The renderer became retained-mode in the July 2026 performance rewrite — previously every event
 rebuilt the whole DOM. The numbers and the root-cause story are in

--- a/docs/docs-site/resources/docs/compiler-plugin.md
+++ b/docs/docs-site/resources/docs/compiler-plugin.md
@@ -1,11 +1,17 @@
 # Compiler plugin
 
+<!-- code: kinetica-compiler/src/KineticaCompilerRegistrar.kt, kinetica-compiler/src/CompilerContract.kt -->
+
 The compiler plugin (`io.heapy.kinetica.compiler`) is a standard part of the toolchain story:
 it removes the ceremony that hand-written Kinetica code carries (explicit `key =` arguments)
 and generates the cross-boundary artifacts for server components. It is a K2
-`CompilerPluginRegistrar` that analyzes sources before compilation and emits generated Kotlin.
+`CompilerPluginRegistrar` whose core is a set of IR transforms plus FIR checkers; with the
+opt-in `sourcePipeline: psi` it additionally analyzes sources before compilation and emits
+generated Kotlin.
 
 ## Annotations
+
+<!-- code: kinetica-runtime/src/Annotations.kt -->
 
 All annotations live in `kinetica-runtime`, so app code needs no extra dependency:
 
@@ -26,12 +32,16 @@ fun AnnotatedApp() {
 
 | Annotation | Purpose |
 |------------|---------|
-| `@UiComponent` | stable `SlotId` generation, desugaring, render skipping, static hoisting |
+| `@UiComponent` | stable `SlotId` generation, desugaring, render skipping (`skippable = false` opts out), static hoisting |
 | `@Preview(name)` | registers a preview entry for tooling |
 | `@ServerComponent` / `@ClientComponent` | marks the server/client boundary for code splitting |
 | `@ServerAction(invalidates = […])` | declares a typed server action and its invalidation keys |
 
 ## Enabling it
+
+<!-- code: common.module-template.yaml, samples/annotated/module.yaml, kinetica-compiler/src/KineticaCommandLineProcessor.kt (pluginOptions) -->
+
+Every Kinetica module applies the shared template (`common.module-template.yaml`), which wires:
 
 ```yaml
 # module.yaml
@@ -39,16 +49,37 @@ settings:
   kotlin:
     compilerPlugins:
       - id: io.heapy.kinetica.compiler
-        dependency: io.heapy.kinetica:kinetica-compiler:0.1.0
+        dependency: io.heapy.kinetica:kinetica-compiler:0.3.0
         options:
           moduleId: my-app
           serverSourceSet: serverMain
           clientSourceSet: clientMain
 ```
 
-See `samples/annotated` for the working wiring.
+Further options and their defaults: `sourcePipeline: lightTree` (`psi` turns on source
+generation), `transforms: all` (`off` is the IR kill switch for debugging), and
+`checks: error` (FIR authoring-rule diagnostics; `warning` downgrades them). See
+`samples/annotated` for the working wiring.
+
+## IR passes
+
+<!-- code: kinetica-compiler/src/KineticaIrTransform.kt, kinetica-compiler/src/KineticaIrTemplate.kt, kinetica-compiler/src/KineticaIrHoist.kt, kinetica-compiler/src/KineticaIrFrames.kt -->
+
+Four transforms run in order on every backend:
+
+1. **Template extraction** — a `host` whose content is a single dynamic `text(…)` over
+   constant props becomes a `templateNode` referencing a hoisted static skeleton; the browser
+   renderer patches such nodes through a clone-and-fill fast path.
+2. **Static hoisting** — constant `propsOf(…)` argument lists and static leaf hosts are
+   interned as file-level fields, so re-renders reuse one instance instead of reallocating.
+3. **Skippable components** — `@UiComponent` bodies get an inputs-equal fast path
+   (`skippableNode`) that re-emits the previous subtree when arguments and read cells are
+   unchanged.
+4. **Frames** — the ordinal assignment described below.
 
 ## What it generates
+
+<!-- code: kinetica-compiler/src/KineticaGeneratedSourceEmitter.kt, kinetica-compiler/src/CompilerContract.kt (responsibilities) -->
 
 Generated symbols land in `io.heapy.kinetica.generated`: component transforms, preview entries,
 server-action registrations + stubs + a dispatcher, the client-component manifest, and route
@@ -57,6 +88,8 @@ static hoisting, the server/client boundary, server-action stubs, diagnostics, h
 protocol, preview entries.
 
 ## The plugin is mandatory
+
+<!-- code: kinetica-compiler/src/KineticaIrFrames.kt (KineticaFrameTransformer), kinetica-compiler/src/KineticaFirExtension.kt (authoring-rule checkers), kinetica-runtime/src/Frames.kt (FrameTable) -->
 
 Kinetica does not have a plugin-less mode. The IR pass (which runs on every backend — JVM,
 JS, wasm, native) assigns each slot- and event-consuming call site a static ordinal inside a

--- a/docs/docs-site/resources/docs/data.md
+++ b/docs/docs-site/resources/docs/data.md
@@ -1,9 +1,13 @@
 # Data & offline
 
+<!-- code: kinetica-data/src/Data.kt -->
+
 `kinetica-data` layers real-world data concerns over the core
 [resource loop](/docs/resources): retries, optimistic mutations, pagination, and offline caches.
 
 ## Retry
+
+<!-- code: kinetica-data/src/Data.kt (RetryPolicy, retry, awaitWithRetry) -->
 
 ```kotlin
 val user = retry(RetryPolicy(attempts = 3, delayMillis = 250, backoffMultiplier = 2.0)) { attempt ->
@@ -19,6 +23,8 @@ cancelled retry loop never spins. `awaitWithRetry` invalidates the resource betw
 each retry re-runs the loader.
 
 ## Optimistic actions
+
+<!-- code: kinetica-data/src/Data.kt (optimisticAction), kinetica-runtime/src/Resources.kt (action) -->
 
 ```kotlin
 val addTodo = optimisticAction(
@@ -37,6 +43,8 @@ version through the normal resource loop.
 
 ## Pagination
 
+<!-- code: kinetica-data/src/Data.kt (Paginator, paginator, asLazyItems), kinetica-runtime/src/ComponentScope.kt (lazyEach) -->
+
 ```kotlin
 val pager = paginator<Article>(key = "feed")
 
@@ -53,6 +61,8 @@ returns `Page(items, next, totalCount)` and `isEnd` falls out of `next == null`.
 `asLazyItems()` plugs straight into [`lazyEach`](/docs/lists-and-keys).
 
 ## Offline cache
+
+<!-- code: kinetica-data/src/Data.kt (OfflineCache, InMemoryOfflineCache, OfflineStrategy, OfflineLoad) -->
 
 ```kotlin
 val cache = InMemoryOfflineCache<String, Orders>()

--- a/docs/docs-site/resources/docs/effects.md
+++ b/docs/docs-site/resources/docs/effects.md
@@ -1,9 +1,13 @@
 # Effects & lifecycle
 
+<!-- code: kinetica-runtime/src/Effects.kt (launchEffect, watch, layoutEffect), kinetica-runtime/src/ComponentScope.kt (runPostCommitEffects) -->
+
 Effects are **explicit**. Nothing re-runs because you happened to read a cell — you declare what
 to watch. All effects start after the render commits, never during it.
 
 ## launchEffect
+
+<!-- code: kinetica-runtime/src/Effects.kt (launchEffect, EffectScope.awaitDispose), kinetica-runtime/src/Frames.kt (commitChecks, disposeFrameSlotValue) -->
 
 ```kotlin
 launchEffect {
@@ -15,9 +19,13 @@ launchEffect {
 ```
 
 A coroutine tied to the component's lifetime. `awaitDispose { cleanup }` is the teardown hook.
-Returns an `EffectHandle` with `cancel()` if you need to stop it early.
+Returns an `EffectHandle` with `cancel()` if you need to stop it early. The lifetime is enforced
+by the frame model: the effect lives in a *transient* slot, so when a committed render no longer
+reaches its call site the effect is cancelled and disposed.
 
 ## watch — react to data changes
+
+<!-- code: kinetica-runtime/src/Effects.kt (watch, WatchEffectState), kinetica-runtime/src/KineticaRuntime.kt (watchLoopRestartLimit) -->
 
 ```kotlin
 watch(source = { userId }) { id ->
@@ -27,11 +35,13 @@ watch(source = { userId }) { id ->
 
 `watch` tracks the cells read inside `source` and re-runs `block` when the *value* changes
 (structural equality by default — pass `equals =` to override). This is the spec'd alternative to
-dependency arrays: the dependency is the expression itself. A restart-loop guard
-(`watchLoopRestartLimit`, default 32) turns a watch that keeps invalidating itself into a
-diagnosable error instead of a hang.
+dependency arrays: the dependency is the expression itself. In debug mode a restart-loop guard
+(`watchLoopRestartLimit`, default 32) stops a watch that keeps invalidating itself and records a
+`WatchLoop` journal entry naming the culprit — a diagnosable stop instead of a silent hang.
 
 ## layoutEffect
+
+<!-- code: kinetica-runtime/src/Effects.kt (layoutEffect), kinetica-router/src/Router.kt (NavHost layoutEffect) -->
 
 ```kotlin
 layoutEffect { /* runs synchronously at commit, before the frame is shown */ }
@@ -42,10 +52,23 @@ navigation state.
 
 ## Event handlers
 
+<!-- code: kinetica-runtime/src/Effects.kt (event), kinetica-browser/src@js/BrowserKineticaApp.kt (dispatchAndRender) -->
+
 `event {}` / `event<T> {}` are covered in [State](/docs/state); they are the only way user input
 enters the loop: event → cell writes → one synchronous commit → effects.
 
+## Try it
+
+<!-- code: docs/docs-client/src/main.kt (EffectTimerExample) -->
+
+::: example effect-timer
+
+The stopwatch is one `watch` whose block loops while `running` is true — flipping the cell
+cancels the previous block and starts a new one, so Stop is just a state write.
+
 ## Exit lifecycle
+
+<!-- code: kinetica-runtime/src/Boundary.kt (exitGroup, onExit, ExitScope, asLeaving), kinetica-motion/src/Motion.kt (exitTransition) -->
 
 Removal is a first-class phase. Wrap removable content in an `exitGroup`; when `visible` flips
 false the subtree is retained, exit callbacks run, and only then does it unmount:
@@ -76,10 +99,14 @@ silently.
 
 ## The journal sees everything
 
-Every effect start, cancellation, watch restart and cell write lands in the runtime journal with
-its cause. When "why did this re-render?" comes up, read `runtime.journal()` — or replay it:
+<!-- code: kinetica-runtime/src/Journal.kt (JournalKind, JournalReplay), kinetica-runtime/src/KineticaRuntime.kt (journal, replay) -->
+
+In debug mode, every effect start, cancellation, watch restart and cell write lands in the
+runtime journal with its cause (production runtimes skip journaling). When "why did this
+re-render?" comes up, read `runtime.journal()` — or replay it:
 
 ```kotlin
 val replay = runtime.replay()
-replay.stateAt(sequence)     // reconstructed state snapshots over time
+replay.stateAt(sequence)     // reconstructed state at that journal entry
+replay.states()              // the series over time
 ```

--- a/docs/docs-site/resources/docs/forms.md
+++ b/docs/docs-site/resources/docs/forms.md
@@ -1,9 +1,13 @@
 # Forms
 
+<!-- code: kinetica-forms/src/Forms.kt (FormState, FieldState) -->
+
 `kinetica-forms` models a form as reactive field cells plus suspend-friendly validation — no
 special components, just state that composes with the [UI DSL](/docs/ui-dsl).
 
 ## Fields and validation
+
+<!-- code: kinetica-forms/src/Forms.kt (formState, field, validators, required, minLength, textInput) -->
 
 ```kotlin
 val form = formState()
@@ -31,6 +35,8 @@ validators with `validators(a, b, …)` — first failure wins.
 
 ## Field state is reactive
 
+<!-- code: kinetica-forms/src/Forms.kt (FieldState, getValue, setValue) -->
+
 `FieldState` exposes `error`, `isTouched`, `isValidating`, `isDirty`, `isValid` — all backed by
 cells, so rendering them subscribes and validation results update the UI without plumbing.
 
@@ -38,7 +44,18 @@ cells, so rendering them subscribes and validation results update the UI without
 var emailValue by email        // property delegation onto the field's value cell
 ```
 
+## Try it
+
+<!-- code: docs/docs-client/src/main.kt (FormSignupExample) -->
+
+::: example form-signup
+
+The form above is `formState()` + two `field`s with validators, a bound `textInput` per field,
+and `form.submit {}` behind the button — running in your browser against this page's bundle.
+
 ## Submission semantics
+
+<!-- code: kinetica-forms/src/Forms.kt (FormState.submit, validate, isValid, reset) -->
 
 ```kotlin
 val submitted = form.submit {
@@ -57,6 +74,8 @@ through an `if (form.isValid) submit()` guard.
 `form.reset()` returns every field to its initial value and clears validation state.
 
 ## Binding to plain vars
+
+<!-- code: kinetica-forms/src/Forms.kt (textInput KMutableProperty0 overload) -->
 
 For quick cases there is a `textInput` overload bound to any `var` via property reference:
 

--- a/docs/docs-site/resources/docs/getting-started.md
+++ b/docs/docs-site/resources/docs/getting-started.md
@@ -1,16 +1,25 @@
 # Getting started
 
+<!-- code: project.yaml, kotlin (wrapper CLI) -->
+
 Kinetica builds with the JetBrains Kotlin Toolchain (the Amper successor): declarative YAML
 modules, a `./kotlin` wrapper CLI, no Gradle.
 
 ## Project layout
 
+<!-- code: samples/browser-counter/module.yaml, common.module-template.yaml (compiler plugin wiring), kinetica-runtime/src/HostDsl.kt -->
+
 A project is a `project.yaml` listing modules; a module is a directory with a `module.yaml`.
-A minimal browser app:
+A minimal browser app (the `apply` template wires the **mandatory**
+[compiler plugin](/docs/compiler-plugin) — without it every `state`/`event` call throws
+`MissingKineticaPluginException` at runtime):
 
 ```yaml
 # module.yaml
 product: js/app
+
+apply:
+  - ../../common.module-template.yaml   # registers io.heapy.kinetica:kinetica-compiler
 
 dependencies:
   - ../../kinetica-browser
@@ -46,6 +55,8 @@ fun main() {
 
 ## Build and run
 
+<!-- code: kotlin (wrapper CLI), scripts/verify-browser.mjs -->
+
 ```
 ./kotlin build -m my-app        # emits build/tasks/_my-app_linkJs/my-app.mjs
 ./kotlin test -m my-module      # run a module's tests
@@ -57,6 +68,8 @@ open the page. JVM apps (`product: jvm/app`) run with `./kotlin run -m my-server
 an executable jar with `./kotlin package`.
 
 ## Components are plain functions
+
+<!-- code: kinetica-runtime/src/Annotations.kt (UiComponent), kinetica-runtime/src/ComponentScope.kt (state, each) -->
 
 There is no component class and no special file type. A component is a function with
 `ComponentScope` as receiver that *emits* nodes:
@@ -77,6 +90,8 @@ gets its own slot automatically. Lists still key their rows explicitly:
 `each(items, key = { … })`.
 
 ## Mounting choices
+
+<!-- code: kinetica-browser/src@js/BrowserKineticaApp.kt (mountKineticaApp), kinetica-runtime/src/KineticaRuntime.kt (render), kinetica-test/src/KineticaTest.kt (KineticaTest.render) -->
 
 | Entry point | Use for |
 |-------------|---------|

--- a/docs/docs-site/resources/docs/index.md
+++ b/docs/docs-site/resources/docs/index.md
@@ -1,5 +1,7 @@
 # Kinetica
 
+<!-- code: kinetica-runtime/src/Node.kt (Node), kinetica-runtime/src/KineticaRuntime.kt (render) -->
+
 Kinetica is a Kotlin UI framework built around one idea: **the UI is a value**. Every render
 produces an immutable, serializable `Node` tree. Because the tree is a value, you get things most
 frameworks bolt on afterwards, for free and by construction: headless testing, HTML server
@@ -31,19 +33,23 @@ fun main() {
 
 ## Design pillars
 
+<!-- code: kinetica-runtime/src/Node.kt, kinetica-runtime/src/Cell.kt, kinetica-runtime/src/Journal.kt (JournalReplay), kinetica-runtime/src/KineticaRuntime.kt (replay) -->
+
 - **`Node` is a serializable value.** Trees can be asserted in tests, snapshotted, sent over the
   wire as server components, and diffed for minimal DOM patches.
 - **One UI loop, atomic commit.** An event runs, cells update, one render commits synchronously.
   No tearing, no partially applied states, no scheduling heuristics to debug.
-- **One reactive primitive.** `state`, `derived`, `store`, contexts and resources are all cells
-  with dependency tracking. Effects are explicit (`watch`, `launchEffect`) — no auto-tracking
-  surprises.
+- **One reactive primitive.** `state`, `derived` and `store` are all cells with dependency
+  tracking, and resources cache through the same machinery. Effects are explicit
+  (`watch`, `launchEffect`) — no auto-tracking surprises.
 - **Linear causality.** The runtime journals every event, cell write, render cause and effect.
   `replay()` reconstructs state at any point. Debuggability outranks features.
 - **Batteries included.** Router, forms, motion, data/offline, persistence, theming, markdown and
   a test harness are first-party modules with the same conventions.
 
 ## Where things run
+
+<!-- code: kinetica-browser/src@js/BrowserKineticaApp.kt, kinetica-runtime/src/ServerComponents.kt, kinetica-test/src/KineticaTest.kt -->
 
 | Target | Module | What you get |
 |--------|--------|--------------|
@@ -52,6 +58,8 @@ fun main() {
 | Headless | `kinetica-test` | Render, click, input and snapshot components without any DOM |
 
 ## Reading order
+
+<!-- code: docs/docs-site/src/Pages.kt (DocPages) -->
 
 Start with [Getting started](/docs/getting-started), then the Core section in order:
 [State & reactivity](/docs/state), [UI DSL](/docs/ui-dsl), [Lists & keys](/docs/lists-and-keys),

--- a/docs/docs-site/resources/docs/lists-and-keys.md
+++ b/docs/docs-site/resources/docs/lists-and-keys.md
@@ -1,6 +1,10 @@
 # Lists & keys
 
+<!-- code: kinetica-runtime/src/ComponentScope.kt (each, keyed, lazyEach) -->
+
 ## each
+
+<!-- code: kinetica-runtime/src/ComponentScope.kt (each, renderEachRegion), kinetica-runtime/src/Frames.kt (enterKeyedChild), kinetica-browser/src/ListReconcile.kt -->
 
 ```kotlin
 each(todos, key = { it.id }) { todo ->
@@ -25,6 +29,8 @@ Keys must be unique within one `each`. In debug mode a duplicate key fails the r
 in production the last item wins.
 
 ## Row memoization
+
+<!-- code: kinetica-runtime/src/ComponentScope.kt (renderEachRegion, frameSkipHit, markEachCapturesUnsafe), kinetica-runtime/src/Frames.kt (FrameSkipCache) -->
 
 `each` also **memoizes each row's output**. When an item is `==` to the previous render's, every
 cell the row read reports an unchanged version, and every context value it read is unchanged,
@@ -51,17 +57,23 @@ Two practical consequences:
 
 ## Try it
 
+<!-- code: docs/docs-client/src/main.kt (KeyedListExample) -->
+
 ::: example keyed-list
 
 Reverse moves the existing DOM elements — watch selection and element identity survive.
 
 ## keyed
 
+<!-- code: kinetica-runtime/src/ComponentScope.kt (keyed, keyedRegion) -->
+
 `keyed(key) { … }` gives a single subtree a frame per key — useful when a component's
 identity should follow data rather than the call site (e.g. a detail panel keyed by the
 selected id, so switching ids resets its state deliberately).
 
 ## lazyEach — windowed lists
+
+<!-- code: kinetica-runtime/src/ComponentScope.kt (lazyEach, lazyItems, LazyListState, RetainPolicy) -->
 
 ```kotlin
 val items = lazyItems(allRows, estimatedSize = allRows.size)
@@ -72,8 +84,9 @@ lazyEach(items, key = { it.id }, state = scroll, retain = RetainPolicy.Keyed) { 
 }
 ```
 
-`lazyEach` renders only `state.visibleRange` — the built-in lever for huge lists. `RetainPolicy`
-controls what happens to off-screen items' state:
+`lazyEach` renders only the rows in `state.visibleRange(total)` — the built-in lever for huge
+lists. A `placeholder` parameter renders in place of a visible row whose resources are still
+pending. `RetainPolicy` controls what happens to off-screen items' state:
 
 | Policy | Off-screen item state |
 |--------|-----------------------|
@@ -86,6 +99,8 @@ controls what happens to off-screen items' state:
 navigation restores scroll position.
 
 ## Where keys come from
+
+<!-- code: kinetica-runtime/src/ComponentScope.kt (keyedLastWins, duplicateKey) -->
 
 Prefer stable domain ids. Never use the item index as a key — an insertion at the head would
 re-key every row, which turns a 1-row change into an every-row update (state *and* DOM).

--- a/docs/docs-site/resources/docs/markdown.md
+++ b/docs/docs-site/resources/docs/markdown.md
@@ -1,10 +1,14 @@
 # Markdown
 
+<!-- code: kinetica-markdown/src/Markdown.kt (parseMarkdown), kinetica-markdown/src/MarkdownRenderer.kt (markdown, MarkdownOptions) -->
+
 `kinetica-markdown` parses Markdown into an AST and renders it as Kinetica nodes — which is how
 **this site works**: every page is a `.md` resource, parsed on the JVM, rendered through the same
 `ComponentScope` DSL as any component, and serialized with `toSafeHtml()`.
 
 ## Usage
+
+<!-- code: kinetica-markdown/src/MarkdownRenderer.kt (ComponentScope.markdown) -->
 
 ```kotlin
 import io.heapy.kinetica.markdown.markdown
@@ -22,14 +26,17 @@ inside a router entry, be server-rendered, be snapshot-tested, and inherit page 
 
 ## Supported syntax
 
+<!-- code: kinetica-markdown/src/Markdown.kt (parseMarkdown, parseInlines), kinetica-markdown/src/CodeHighlight.kt (MarkdownCodeHighlighter) -->
+
 | Feature | Notes |
 |---------|-------|
 | Headings `#`–`######` | h2+ get `id` anchors derived from their text |
-| Paragraphs, `**bold**`, `*italic*`, `` `code` `` | inline nesting supported |
+| Paragraphs, `**bold**`, `*italic*`, `` `code` `` | `__`/`_` delimiters too; inline nesting supported |
 | Links `[label](href)` | hrefs pass the runtime's URL sanitizer — `javascript:` never renders |
 | Fenced code blocks ```` ```lang ```` | server-side spans for Kotlin, JSON, HTML, and YAML; unsupported languages keep `class="language-…"` |
-| Lists `-` / `1.` | single level, continuation lines |
+| Lists `-` / `*` / `1.` / `1)` | single level, continuation lines |
 | Blockquotes, `---` rules, tables | GFM-style pipe tables |
+| HTML comments `<!-- … -->` | skipped entirely — these docs use them to link sections to source files |
 | Directives `::: name argument` | extension point, see below |
 
 Parsing is available standalone: `parseMarkdown(source): List<MdBlock>` with a small typed AST
@@ -38,13 +45,15 @@ Parsing is available standalone: `parseMarkdown(source): List<MdBlock>` with a s
 
 ## Directives — embedding live components
 
+<!-- code: kinetica-markdown/src/MarkdownRenderer.kt (MarkdownOptions.directive), docs/docs-site/src/Layout.kt (renderDirective), docs/docs-client/src/main.kt (main) -->
+
 A directive line hands control back to your code mid-document:
 
 ```kotlin
 markdown(source, MarkdownOptions(directive = { name, argument ->
     when (name) {
         "example" -> { LiveExample(argument); true }
-        else -> false                       // unhandled directives render nothing
+        else -> false                       // render nothing — an unhandled directive emits no nodes
     }
 }))
 ```
@@ -56,6 +65,8 @@ mounts an interactive app into it:
 ::: example counter
 
 ## Safety by construction
+
+<!-- code: kinetica-markdown/src/MarkdownRenderer.kt (renderInlines), kinetica-runtime/src/Html.kt (toSafeHtml, isSafeHtmlAttributeValue) -->
 
 The renderer never emits raw HTML. Text becomes `TextNode`s (escaped by every serializer),
 attributes go through the same allowlist as hand-written components, and unsafe URL schemes are

--- a/docs/docs-site/resources/docs/motion.md
+++ b/docs/docs-site/resources/docs/motion.md
@@ -1,10 +1,14 @@
 # Motion
 
+<!-- code: kinetica-motion/src/Motion.kt, kinetica-runtime/src/Boundary.kt (FrameValue) -->
+
 Animation in Kinetica keeps the value-tree model intact: animated numbers are **frame values** —
 mutable floats that live *outside* the node tree and bind to nodes via `frameProps`. A running
 animation never re-renders components; it only updates frame bindings.
 
 ## Frame values
+
+<!-- code: kinetica-runtime/src/Boundary.kt (FrameValue, frameValue), kinetica-runtime/src/HostDsl.kt (host frameProps) -->
 
 ```kotlin
 val opacity = frameValue(0f)                     // runtime primitive
@@ -23,6 +27,8 @@ renderer-agnostic like everything else in the tree.
 
 ## Animated values
 
+<!-- code: kinetica-motion/src/Motion.kt (AnimatedFloat, animate, AnimationSpec, Easing) -->
+
 ```kotlin
 val scale = animate(
     initial = 0f,
@@ -33,13 +39,14 @@ val scale = animate(
 host("div", frameProps = mapOf("scale" to scale.frameValue)) { … }
 
 scale.animateTo(0.5f)                            // retarget mid-flight
-scale.interrupt(0f, AnimationSpec.Tween(120))    // replace spec and target
+scale.interrupt(0f, AnimationSpec.Tween(120))    // retarget with a new spec
 scale.snapTo(1f)                                 // jump, no animation
 scale.advanceBy(16)                              // advance the clock by one frame
 ```
 
 Specs: `Tween(durationMillis, easing)` with `Linear / EaseIn / EaseOut / EaseInOut`, and
-physical `Spring(stiffness, dampingRatio, visibilityThreshold)`. `animate()` survives
+spring-like `Spring(stiffness, dampingRatio, visibilityThreshold)` (integrated as an
+exponential-decay approximation, not full spring physics). `animate()` survives
 re-renders — calling it again with a new `target` retargets the existing animation instead of
 restarting it.
 
@@ -49,6 +56,8 @@ why animations are deterministic in tests: `advanceBy(100)` twice lands exactly 
 end state.
 
 ## Enter & exit
+
+<!-- code: kinetica-motion/src/Motion.kt (enterTransition, exitTransition), kinetica-runtime/src/Boundary.kt (exitGroup, onExit, asLeaving) -->
 
 ```kotlin
 val enter = enterTransition()                    // 0 -> 1, 180ms ease-out by default
@@ -66,6 +75,8 @@ before the subtree unmounts — the runtime retains the leaving tree, marks it w
 semantics, and force-completes after a debug timeout if an animation stalls.
 
 ## Drag gestures
+
+<!-- code: kinetica-motion/src/Motion.kt (DragGesture, dragGesture, frameProps) -->
 
 ```kotlin
 val drag = dragGesture(onEnd = { offset -> settle(offset) })

--- a/docs/docs-site/resources/docs/performance.md
+++ b/docs/docs-site/resources/docs/performance.md
@@ -76,9 +76,9 @@ React):
    first time: swap1k 0.36×, swap10k 0.78×, replace1k and create10k 0.90×; remove10k (1.48×)
    and update-every-10th-10k (1.26×) are the remaining open items.
 
-The open performance backlog lives in `plan.md` at the repository root (KNT tickets); the full
-root-cause analysis and phase history are preserved in that file's Context section and in the
-git history of the retired `perf-rewrite-design.md`.
+The remaining open items are tracked as KNT tickets in `plan.md` at the repository root;
+the full root-cause analysis, phase gates and measurement methodology live in the git
+history of `perf-rewrite-design.md` (retired into `plan.md`, July 2026).
 
 ## What the suite measures
 

--- a/docs/docs-site/resources/docs/performance.md
+++ b/docs/docs-site/resources/docs/performance.md
@@ -1,43 +1,51 @@
 # Performance
 
+<!-- code: bench/results/results.json, bench/driver/bench.mjs, bench/README.md -->
+
 Kinetica is benchmarked continuously against React, Preact, Vue, Svelte and a vanilla-JS
 baseline using a local reimplementation of the **js-framework-benchmark** (krausest) keyed
 suite: identical table apps, one machine, one Chromium, one Playwright/Chrome-trace driver.
 Duration = trusted click → end of last paint.
 
-## Where Kinetica stands (2026-07-06, M4 Max, Chromium 149)
+## Where Kinetica stands (2026-07-07, M4 Max, Chromium 149)
+
+<!-- code: bench/results/results.json, bench/results/part-kinetica.json -->
 
 Median milliseconds; geometric-mean slowdown vs the per-operation fastest framework. The
-Kinetica column was refreshed in a Kinetica-only pass; the comparison columns are same-day
-13-operation reference results from the full suite.
+Kinetica and vanilla columns were re-measured after the frame-ordinals rewrite (vanilla median
+drift vs its stored part ≤2%, so cross-part comparison holds); the other columns are stored
+same-day parts from the full suite.
 
 | Operation | Kinetica | React | Preact | Vue | Svelte | Vanilla |
 |---|---:|---:|---:|---:|---:|---:|
-| create 1,000 rows | 30.0 | 33.5 | 32.6 | 36.1 | 26.3 | 28.0 |
-| replace all 1,000 rows | 33.3 | 37.4 | 33.2 | 34.2 | 31.4 | 31.3 |
-| partial update (every 10th row) | 7.7 | 7.0 | 7.6 | 8.1 | 7.2 | 7.3 |
-| select row | 7.1 | 7.6 | 7.4 | 7.2 | 7.4 | 7.5 |
-| swap two rows | 7.3 | 22.4 | 7.3 | 8.3 | 7.8 | 7.4 |
-| remove one row | 8.4 | 7.4 | 7.4 | 7.2 | 7.2 | 7.1 |
-| create 10,000 rows | 298 | 316 | 245 | 234 | 204 | 208 |
-| append 1,000 rows to 1,000 | 39.5 | 32.8 | 39.3 | 30.9 | 32.3 | 30.1 |
-| clear 1,000 rows | 6.9 | 7.2 | 6.8 | 6.9 | 6.9 | 7.0 |
-| select row (10k table) | 8.4 | 7.9 | 7.9 | 15.2 | 7.7 | 8.0 |
-| swap two rows (10k table) | 41.2 | 54.1 | 35.6 | 42.7 | 29.9 | 28.7 |
-| remove one row (10k table) | 55.7 | 40.3 | 40.8 | 53.8 | 38.8 | 44.9 |
-| partial update (every 10th of 10k) | 44.5 | 34.4 | 36.6 | 45.1 | 29.4 | 31.8 |
-| **geometric mean** | **1.20×** | 1.27× | 1.11× | 1.23× | 1.02× | 1.04× |
+| create 1,000 rows | 34.9 | 33.5 | 32.6 | 36.1 | 26.3 | 25.5 |
+| replace all 1,000 rows | 33.6 | 37.4 | 33.2 | 34.2 | 31.4 | 32.6 |
+| partial update (every 10th row) | 8.0 | 7.0 | 7.6 | 8.1 | 7.2 | 7.6 |
+| select row | 7.8 | 7.6 | 7.4 | 7.2 | 7.4 | 7.6 |
+| swap two rows | 8.1 | 22.5 | 7.3 | 8.3 | 7.8 | 7.4 |
+| remove one row | 8.5 | 7.4 | 7.4 | 7.2 | 7.2 | 7.3 |
+| create 10,000 rows | 284 | 316 | 245 | 234 | 204 | 206 |
+| append 1,000 rows to 1,000 | 34.6 | 32.8 | 39.3 | 30.9 | 32.3 | 28.2 |
+| clear 1,000 rows | 7.0 | 7.2 | 6.8 | 6.9 | 6.9 | 7.0 |
+| select row (10k table) | 8.7 | 7.9 | 7.9 | 15.2 | 7.7 | 7.9 |
+| swap two rows (10k table) | 42.1 | 54.1 | 35.6 | 42.7 | 30.0 | 28.3 |
+| remove one row (10k table) | 59.8 | 40.3 | 40.8 | 53.8 | 38.8 | 44.4 |
+| partial update (every 10th of 10k) | 43.3 | 34.4 | 36.6 | 45.1 | 29.4 | 32.1 |
+| **geometric mean** | **1.24×** | 1.28× | 1.12× | 1.24× | 1.03× | 1.04× |
 
-Kinetica's current 13-op headline is **1.20×**, ahead of React's **1.27×** in this comparison.
-It is ahead of React on create-10k (298 ms vs 316 ms), startup (22.6 ms vs 27.3 ms), and the
-1k-row swap case (7.3 ms vs 22.4 ms). The 1k partial operations sit near the paint floor; the
-10k partial operations show the remaining work: large-table swap/remove/update still scale with
-row count.
+Kinetica's 13-op headline against React directly is **0.969×** — ahead of React overall for the
+first time. It wins create-10k (284 ms vs 316 ms), startup (24.5 ms vs 27.3 ms), and both swap
+cases (8.1 ms vs 22.5 ms on 1k; 42.1 ms vs 54.1 ms on 10k). The 1k partial operations sit near
+the paint floor; remove-10k (1.48× React) and update-every-10th-10k (1.26×) are the remaining
+open items — large-table remove/update still scale with row count.
 
 ## How it got there
 
-The July 2026 rewrite moved the original 9-op geometric mean from **15.2× to roughly 1.1×**. The
-current 13-op headline is **1.20×** after adding the 10k-table partial operations:
+<!-- code: kinetica-browser/src@js/BrowserKineticaApp.kt (retained renderer), kinetica-runtime/src/Frames.kt (frame ordinals), kinetica-runtime/src/ComponentScope.kt (each memoization), kinetica-compiler/src/KineticaIrFrames.kt -->
+
+The July 2026 rewrite moved the original 9-op geometric mean from **15.2× to roughly 1.1×**;
+frame ordinals then took the 13-op headline below React for the first time (**0.97×** vs
+React):
 
 1. **Event registry fix (15.2× → 3.0×).** Profiling showed 60–67% of all CPU in an O(n)
    identity scan run per handler per render — O(n²) per operation and leaking. A hash map with
@@ -57,8 +65,9 @@ current 13-op headline is **1.20×** after adding the 10k-table partial operatio
    maintained key-scope prefix. Create-10k dropped from 474 ms to roughly 300 ms.
 6. **Browser fast-paths + benchmark bundling.** The browser renderer avoids repeated tag/attribute
    classification work, and the benchmark now loads Kinetica through a post-link esbuild production
-   bundle instead of the Kotlin Toolchain preview multi-file graph. Startup is 22.6 ms with one JS
-   file and an 82 KB gzip payload.
+   bundle instead of the Kotlin Toolchain preview multi-file graph. Startup dropped to 22.6 ms
+   at this phase with one JS file and an 82 KB gzip payload (24.5 ms / 85 KB after frame
+   ordinals).
 7. **Frame ordinals (1.20× → 0.97×).** The compiler plugin became mandatory and slot identity
    moved to compile time: every `state`/`derived`/effect call site gets a static ordinal in a
    per-component frame, so the hot path reads slots by array index — no key strings, no
@@ -67,10 +76,13 @@ current 13-op headline is **1.20×** after adding the 10k-table partial operatio
    first time: swap1k 0.36×, swap10k 0.78×, replace1k and create10k 0.90×; remove10k (1.48×)
    and update-every-10th-10k (1.26×) are the remaining open items.
 
-The full root-cause analysis, phase gates and measurement methodology live in
-`perf-rewrite-design.md` at the repository root.
+The open performance backlog lives in `plan.md` at the repository root (KNT tickets); the full
+root-cause analysis and phase history are preserved in that file's Context section and in the
+git history of the retired `perf-rewrite-design.md`.
 
 ## What the suite measures
+
+<!-- code: bench/run-all.mjs, bench/driver/tree.mjs, bench/driver/scaling.mjs, bench-jvm/src, scripts/size-report.mjs -->
 
 Beyond the classic nine operations, the harness tracks the regressions that a single-size,
 single-click table can't see:
@@ -86,7 +98,9 @@ single-click table can't see:
 - **Deep tree** — a 1,555-node keyed tree (create, leaf updates, subtree moves, and a no-op
   re-render that isolates pure reconciliation overhead per framework).
 - **Memory churn and leaks** — heap after replace/create-clear cycles and after repeated
-  mount/unmount cycles through each app's teardown path.
+  mount/unmount cycles through each app's teardown path. This gate is currently the one open
+  regression: heap after 1k rows is 5.7 MB against a ≤5 MB target (React 4.4 MB, vanilla
+  1.9 MB).
 - **CPU-throttled pass** — the whole suite under 4× CDP throttling as a low-end-device proxy.
 - **JVM microbenchmarks** (`bench-jvm` module) — reactive-core propagation, render-pipeline
   Node construction and markdown SSR throughput, minutes-fast for per-PR regression checks.
@@ -94,6 +108,8 @@ single-click table can't see:
   `bench/size-baseline.json`.
 
 ## Performance model
+
+<!-- code: kinetica-runtime/src/Node.kt (diffNodes), kinetica-runtime/src/ComponentScope.kt (renderEachRegion), bench/results/sizes.json -->
 
 - An event costs: handler + node-tree build + **diff O(tree) + patch O(changes)** + paint.
 - Unchanged subtrees compare cheaply; reference-equal subtrees (memoized `each` rows,
@@ -104,10 +120,12 @@ single-click table can't see:
   safe (`n^0.23`) and update as sublinear-to-linear (`n^0.86`), but swap exceeds its near-flat
   threshold (`n^0.84` vs 0.6).
 - The benchmark payload uses a post-link esbuild bundle over Kotlin/JS output while the Kotlin
-  Toolchain `js/app` product is still a preview. Kinetica now starts in 22.6 ms with one
-  82 KB gzip JS file in the benchmark, versus React's 27.3 ms and 60 KB gzip.
+  Toolchain `js/app` product is still a preview. Kinetica now starts in 24.5 ms with one
+  85 KB gzip JS file in the benchmark, versus React's 27.3 ms and 62 KB gzip.
 
 ## Reproducing
+
+<!-- code: bench/run-all.mjs, bench/README.md, scripts/size-report.mjs -->
 
 ```
 cd bench

--- a/docs/docs-site/resources/docs/persist.md
+++ b/docs/docs-site/resources/docs/persist.md
@@ -1,10 +1,14 @@
 # Persistence
 
+<!-- code: kinetica-persist/src/Persist.kt, kinetica-runtime/src/ComponentScope.kt (SlotId) -->
+
 State survives process death through **slot persistence**: state slots addressed by stable ids,
 bridged to a storage backend explicitly. Also here: the theme battery, Kinetica's other ambient
 state module.
 
 ## Stable slot ids
+
+<!-- code: kinetica-runtime/src/ComponentScope.kt (SlotId, state slotId overload), kinetica-runtime/src/Frames.kt (persistentSlotIds) -->
 
 ```kotlin
 val DraftSlot = SlotId(
@@ -25,24 +29,33 @@ itself**; durability comes from the save/restore bridge below.
 
 ## Saving and restoring
 
+<!-- code: kinetica-persist/src/Persist.kt (persistentState, restoreSlot, saveSlot, persistentSlot, restoreSlots, saveSlots) -->
+
 ```kotlin
-val backend = JsonSlotPersistenceBackend()          // or your own SlotPersistenceBackend
+val backend = JsonSlotPersistenceBackend()   // reference backend: JSON over an in-memory store
 
 // on save points (suspend):
 scope.saveSlot(DraftSlot, backend, String.serializer())
 
-// on startup, before rendering (suspend):
-scope.restoreSlot(DraftSlot, backend, String.serializer())
-scope.render {
+// on startup — restore into the scope, then render with it:
+val scope = ComponentScope(runtime)
+scope.restoreSlot(DraftSlot, backend, String.serializer())   // parks the value in the scope
+runtime.render(scope) {
     var draft by persistentState(slotId = DraftSlot, restoredValue = readSlot(DraftSlot)) { "" }
 }
 ```
+
+`JsonSlotPersistenceBackend` handles serialization but stores strings in memory — it is the
+reference implementation, not durable storage. Real durability comes from a
+`StringSlotPersistenceStore` over platform storage (see Backends below).
 
 Writing `null` into a present slot removes the backend entry — cleared state does not resurrect
 on the next launch. Batch variants: `persistentSlot(slotId, serializer)` bindings +
 `restoreSlots` / `saveSlots`.
 
 ## Backends
+
+<!-- code: kinetica-persist/src/Persist.kt (SlotPersistenceBackend, StringSlotPersistenceBackend, DataStoreSlotPersistenceBackend, LocalStorageSlotPersistenceBackend, NSUserDefaultsSlotPersistenceBackend) -->
 
 `SlotPersistenceBackend` is three suspend functions (`read`, `write`, `remove`).
 `StringSlotPersistenceBackend` handles JSON encoding over any `StringSlotPersistenceStore` —
@@ -51,6 +64,8 @@ implement the string store over your platform storage. The shipped
 store you provide**, not built-in platform integrations.
 
 ## Theming (kinetica-theme)
+
+<!-- code: kinetica-theme/src/Theme.kt (Theme, ColorTokens, provideTheme, theme, breakpointFor, directional) -->
 
 Ambient design tokens ride the [context system](/docs/ui-dsl):
 

--- a/docs/docs-site/resources/docs/resources.md
+++ b/docs/docs-site/resources/docs/resources.md
@@ -1,10 +1,14 @@
 # Resources & boundaries
 
+<!-- code: kinetica-runtime/src/Resources.kt (resource, Resource), kinetica-runtime/src/Boundary.kt (errorBoundary, loadingBoundary) -->
+
 The data-loading loop is **resource → read → invalidate**: declare an async source, read it like
 a value, invalidate it to refetch. Loading and failure are handled structurally by boundaries,
 not by hand-rolled `isLoading` flags.
 
 ## Declaring and reading
+
+<!-- code: kinetica-runtime/src/Resources.kt (resource, ResourceImpl.read, await), kinetica-runtime/src/Boundary.kt (loadingBoundaryRegion) -->
 
 ```kotlin
 data object ProfileKey : ResourceKey
@@ -26,6 +30,8 @@ the nearest `errorBoundary`. `await()` is the suspend variant for use inside eff
 
 ## Cache scopes
 
+<!-- code: kinetica-runtime/src/Resources.kt (CacheScope), kinetica-runtime/src/KineticaRuntime.kt (appResourceTtlMillis) -->
+
 | `CacheScope` | Lifetime |
 |--------------|----------|
 | `App` | shared per runtime, optional TTL (`appResourceTtlMillis`) |
@@ -34,8 +40,10 @@ the nearest `errorBoundary`. `await()` is the suspend variant for use inside eff
 
 ## Invalidation
 
+<!-- code: kinetica-runtime/src/Resources.kt (invalidate, ResourceRegistry.invalidate) -->
+
 ```kotlin
-profile.invalidate()              // this resource
+profile.invalidate()              // this resource's key
 invalidate(ProfileKey)            // by key, from anywhere
 invalidate { it is TodosKey }     // by predicate
 ```
@@ -44,6 +52,8 @@ Invalidation drops the cache and re-renders readers; the loader re-runs. Cancell
 cancelled load never poisons the cache as a permanent failure.
 
 ## Actions
+
+<!-- code: kinetica-runtime/src/Resources.kt (action), kinetica-data/src/Data.kt (optimisticAction, retry) -->
 
 Mutations pair with invalidation declaratively:
 
@@ -58,6 +68,8 @@ The [data battery](/docs/data) adds `optimisticAction` (apply → rollback on fa
 policies on top of this loop.
 
 ## Boundaries
+
+<!-- code: kinetica-runtime/src/Boundary.kt (errorBoundaryRegion, loadingBoundaryRegion, suspendSubtreeRegion) -->
 
 ```kotlin
 errorBoundary(
@@ -86,6 +98,8 @@ how much of the content rendered before it threw.
 
 ## Live demo
 
+<!-- code: docs/docs-client/src/main.kt (ResourceFetchExample), docs/docs-site/src/main.kt (demo/api/stack routes) -->
+
 The stack builder below runs the whole loop against this documentation server. The list is a
 `resource` whose loader fetches `GET /demo/api/stack`; adding a language runs an `action` that
 `POST`s it and invalidates the resource key, so readers refetch. Every visitor gets their own
@@ -99,7 +113,8 @@ The backend has opinions. Try adding **Java** — the server throws a
 error propagates from the action into the nearest `errorBoundary`, and *Try again* clears it,
 handing your input back for another attempt.
 
-The client code is the loop from this page, verbatim:
+The client code is the loop from this page (trimmed of markup — the full source is
+`docs/docs-client/src/main.kt`):
 
 ```kotlin
 data object TeamStackKey : ResourceKey

--- a/docs/docs-site/resources/docs/router.md
+++ b/docs/docs-site/resources/docs/router.md
@@ -1,9 +1,13 @@
 # Router & navigation
 
+<!-- code: kinetica-runtime/src/Navigation.kt (BackStack, Route), kinetica-router/src/Router.kt -->
+
 Navigation is core-adjacent by design: `BackStack` lives in the runtime, and the router battery
 (`kinetica-router`) adds the host component, transitions, history and deep links.
 
 ## Routes and the back stack
+
+<!-- code: kinetica-runtime/src/Navigation.kt (BackStack.push, pop, replaceAll) -->
 
 ```kotlin
 @Serializable
@@ -24,6 +28,8 @@ it enforces the invariant that it is never empty.
 
 ## NavHost
 
+<!-- code: kinetica-router/src/Router.kt (NavHost, NavOptions, NavEntry, NavDirection, NavTransition) -->
+
 ```kotlin
 NavHost(stack, options = NavOptions(retainPreviousEntries = 1, restoreScroll = true)) { route ->
     when (route) {
@@ -36,12 +42,15 @@ NavHost(stack, options = NavOptions(retainPreviousEntries = 1, restoreScroll = t
 `NavHost` renders the current route and up to `retainPreviousEntries` previous entries (kept
 mounted, marked retained — the entry you'd return to keeps its state). Dropped entries have
 their non-persistent state disposed. Each entry knows its `NavEntry` — direction
-(`Forward`/`Back`/`Replace`), transition, stack index — via `currentNavEntry()`.
+(`NavDirection`: `Initial`, `Unchanged`, `Forward`, `Back`, `Replace`), transition, stack
+index — via `currentNavEntry()`.
 
 Transitions annotate entries for renderers: `NavOptions(transition = NavTransition.slide(200))`
 (`None`, `fade(ms)`, `slide(ms)`).
 
 ## Scroll restoration
+
+<!-- code: kinetica-router/src/Router.kt (rememberNavScrollState, navLazyEach) -->
 
 ```kotlin
 val scroll = rememberNavScrollState(key = "feed")
@@ -52,6 +61,8 @@ Scroll state persists per navigation entry: navigate away and back, the window p
 restored (`restoreScroll = true`).
 
 ## System back
+
+<!-- code: kinetica-router/src/Router.kt (HostBackDispatcher, InMemoryHostBackDispatcher, bindHostBack) -->
 
 ```kotlin
 val dispatcher = InMemoryHostBackDispatcher()      // adapt to browser/Android back
@@ -65,6 +76,8 @@ a dialog).
 
 ## Serialization, history, deep links
 
+<!-- code: kinetica-router/src/Router.kt (jsonRouteCodec, InMemoryRouteHistory, writeToHistory, restoreFromHistory, deepLink, parseDeepLink) -->
+
 ```kotlin
 val codec = jsonRouteCodec(AppRoute.serializer())   // any RouteCodec<R>
 
@@ -73,7 +86,7 @@ stack.writeToHistory(history, codec)                // push or replace
 stack.restoreFromHistory(history, codec)
 
 val link = codec.deepLink(AppRoute.Details("42"))   // encoded deep link
-val route = codec.parseDeepLink(link.encoded)
+val parsed = codec.parseDeepLink(link.encoded)      // DeepLink<AppRoute>; the route is parsed.route
 ```
 
 Because routes are serializable values, the whole stack round-trips through history storage —

--- a/docs/docs-site/resources/docs/server-components.md
+++ b/docs/docs-site/resources/docs/server-components.md
@@ -1,5 +1,7 @@
 # Server components
 
+<!-- code: kinetica-runtime/src/ServerComponents.kt, docs/docs-site/src/main.kt (server-components demo) -->
+
 Because a rendered UI is a serializable `Node` tree, "server components" is not a separate
 framework — it is the same tree, produced on the JVM and delivered four ways: safe HTML,
 hydration metadata, streamed patches, and typed server actions.
@@ -11,6 +13,8 @@ client island, and a streamed update on one page.
 
 ## 1. Safe HTML
 
+<!-- code: kinetica-runtime/src/Html.kt (toSafeHtml), docs/docs-site/src/Layout.kt (renderDocPage) -->
+
 ```kotlin
 val tree = KineticaRuntime().render { ProductPage() }.tree
 val html = tree.toSafeHtml()
@@ -20,6 +24,8 @@ val html = tree.toSafeHtml()
 of this documentation site is produced exactly this way.
 
 ## 2. Client islands & hydration
+
+<!-- code: kinetica-runtime/src/Node.kt (ClientRef), kinetica-runtime/src/ServerComponents.kt (hydrationPlan, encodeHydrationPlan), samples/server-components-client/src/main.kt -->
 
 Mark an interactive region with a `ClientRef` — a serializable pointer to a client component
 plus its serializable props:
@@ -44,6 +50,8 @@ browser apps into them — the rest of the page stays static HTML with zero clie
 
 ## 3. Streaming
 
+<!-- code: kinetica-runtime/src/ServerComponents.kt (toServerRenderStream, ServerRenderChunk, encodeChunk), docs/docs-site/src/main.kt (GET /stream) -->
+
 Slow parts of a page defer and stream in as **patches against the tree** — the diff format is
 the same serializable value used everywhere else:
 
@@ -56,10 +64,15 @@ tree.toServerRenderStream(
         },
     ),
     manifest = manifest,
-)   // -> a Flow of chunks, encoded as NDJSON by the transport
+)   // -> List<ServerRenderChunk>: the initial chunk, then a Patch per resolved subtree
 ```
 
+Each chunk serializes with `transport.encodeChunk(chunk)`; the demo endpoint joins them with
+newlines into NDJSON, which the client applies as path-addressed subtree replacements.
+
 ## 4. Typed server actions
+
+<!-- code: kinetica-runtime/src/ServerComponents.kt (serverActionStub, KineticaServerActionDispatcher), docs/docs-site/src/main.kt (POST /actions) -->
 
 Client islands call back into the server through declared, schema-validated actions:
 
@@ -90,6 +103,8 @@ message (no stack-trace leaks); `invalidates` keys plug into the
 [resource loop](/docs/resources) on the client.
 
 ## The manifest
+
+<!-- code: kinetica-runtime/src/ServerComponents.kt (ClientComponentManifest, ClientComponentRegistration), kinetica-runtime/src/Annotations.kt (ClientComponent, ServerAction) -->
 
 `ClientComponentManifest` declares which client components and actions exist
 (`componentId → componentFqName`, props types, action registrations) — the contract both sides

--- a/docs/docs-site/resources/docs/state.md
+++ b/docs/docs-site/resources/docs/state.md
@@ -1,10 +1,16 @@
 # State & reactivity
 
-Kinetica has **one reactive primitive: the cell**. `state`, `derived`, `store`, contexts and
-resources are all cells; reads inside render are tracked, writes invalidate exactly the
-components that read them.
+<!-- code: kinetica-runtime/src/Cell.kt (Cell, MutableCell, store), kinetica-runtime/src/ComponentScope.kt (state, derived) -->
+
+Kinetica has **one reactive primitive: the cell**. `state`, `derived` and `store` are all cells
+(resources cache their values in the same machinery); reads inside render are tracked, a write
+invalidates the render, and [memoization](/docs/lists-and-keys) prunes the re-render down to the
+components whose inputs actually changed. Contexts are the one ambient mechanism that is *not* a
+cell — they are scoped values, not reactive state.
 
 ## state
+
+<!-- code: kinetica-runtime/src/ComponentScope.kt (state), kinetica-runtime/src/Frames.kt (Frame.slot) -->
 
 ```kotlin
 var count by state { 0 }
@@ -32,7 +38,15 @@ fun <T> ComponentScope.state(
 ): MutableCell<T>
 ```
 
+Signatures on these pages omit the `ordinal: Int = -1` parameter the compiler plugin fills in
+at every slot-consuming call site — you never pass it yourself. A second overload,
+`state(slotId = …, persistent = true) { … }`, addresses a slot by a stable
+[`SlotId`](/docs/persist) for persistence. The returned `MutableCell` also has
+`update { it + 1 }` for read-modify-write.
+
 ## derived
+
+<!-- code: kinetica-runtime/src/ComponentScope.kt (derived), kinetica-runtime/src/Cell.kt (DerivedCell) -->
 
 ```kotlin
 val remaining by derived { todos.count { !it.done } }
@@ -44,6 +58,8 @@ re-render — `derived { count > 0 }` re-renders its readers only when the boole
 
 ## store — cells outside the render tree
 
+<!-- code: kinetica-runtime/src/Cell.kt (store, peek), kinetica-runtime/src/KineticaRuntime.kt (updateRenderSubscriptions) -->
+
 ```kotlin
 val theme = store(Theme.Light)          // plain reactive cell, no component scope needed
 val current = peek { theme.value }      // read without dependency tracking
@@ -53,6 +69,8 @@ val current = peek { theme.value }      // read without dependency tracking
 field state). Renders that read a store re-render when it changes.
 
 ## Events
+
+<!-- code: kinetica-runtime/src/Effects.kt (event, StableEvent), kinetica-browser/src@js/BrowserKineticaApp.kt (dispatchAndRender) -->
 
 ```kotlin
 val add = event { todos = todos + draft }         // () -> Unit
@@ -66,6 +84,8 @@ configure and no torn intermediate state to observe.
 
 ## Try it
 
+<!-- code: docs/docs-client/src/main.kt (CounterExample, InputMirrorExample) -->
+
 ::: example counter
 
 The counter above is `state` + `derived` + two `event` handlers, mounted with the browser
@@ -75,13 +95,20 @@ renderer. So is this input mirror:
 
 ## Equality policies
 
+<!-- code: kinetica-runtime/src/EqualityPolicy.kt -->
+
 | Policy | Behavior |
 |--------|----------|
 | `structural()` | `==` comparison (default) |
 | `referential()` | `===` comparison |
 | `neverEqual()` | every write invalidates |
 
+`EqualityPolicy` is a `fun interface` — pass `EqualityPolicy { a, b -> … }` for custom
+change detection.
+
 ## Rules of thumb
+
+<!-- code: kinetica-runtime/src/Cell.kt, kinetica-runtime/src/Effects.kt -->
 
 - Model state as immutable values (`data class` copies, new lists). The renderer diffs values —
   mutation in place defeats change detection.

--- a/docs/docs-site/resources/docs/testing.md
+++ b/docs/docs-site/resources/docs/testing.md
@@ -1,9 +1,13 @@
 # Testing
 
+<!-- code: kinetica-test/src/KineticaTest.kt -->
+
 Because rendering produces a value, components test **headlessly** — no DOM, no browser, no
 emulator. `kinetica-test` drives components the way a user would and asserts on trees.
 
 ## The harness
+
+<!-- code: kinetica-test/src/KineticaTest.kt (KineticaTest.render, TestRoot, hasTestTag, hasRole, hasLabel, hasText) -->
 
 ```kotlin
 val root = KineticaTest.render {
@@ -27,6 +31,8 @@ Interactions dispatch through the real event pipeline: `click(matcher)`, `input(
 
 ## Async: the suspend harness
 
+<!-- code: kinetica-test/src/KineticaTest.kt (renderSuspend, SuspendTestRoot.awaitIdle, advanceTimeBy), kinetica-runtime/src/KineticaRuntime.kt (advanceVirtualTimeBy) -->
+
 ```kotlin
 val root = KineticaTest.renderSuspend {
     loadingBoundary(fallback = { text("Loading") }) {
@@ -46,6 +52,8 @@ sleeping.
 
 ## Snapshots
 
+<!-- code: kinetica-test/src/KineticaTest.kt (treeSnapshot, htmlSnapshot, assertTreeSnapshot, assertHtmlSnapshot) -->
+
 Two canonical serializations, both stable and diff-friendly:
 
 ```kotlin
@@ -57,6 +65,8 @@ root.assertHtmlSnapshot(expected)
 
 ## The journal in tests
 
+<!-- code: kinetica-test/src/KineticaTest.kt (TestRoot.journal), kinetica-runtime/src/Journal.kt (JournalEntry, JournalKind) -->
+
 Every test root records the full execution journal — assert on causality itself:
 
 ```kotlin
@@ -65,6 +75,8 @@ assertEquals("cell write", commit.attributes["cause"])
 ```
 
 ## Browser-level verification
+
+<!-- code: samples/browser-tests/src/main.kt, scripts/verify-browser.mjs -->
 
 For renderer behavior that only exists in a real DOM (focus, patched-element identity, input
 cursors), the repo runs Playwright against browser-executed self-tests

--- a/docs/docs-site/resources/docs/ui-dsl.md
+++ b/docs/docs-site/resources/docs/ui-dsl.md
@@ -1,9 +1,15 @@
 # UI DSL & semantics
 
-Components emit nodes with a small DSL. Four node kinds exist: `HostNode` (an element),
-`TextNode`, `FragmentNode`, and `ClientRef` (a [server-component island](/docs/server-components)).
+<!-- code: kinetica-runtime/src/Node.kt (Node, HostNode, TextNode, FragmentNode, TemplateNode, ClientRef) -->
+
+Components emit nodes with a small DSL. Five node kinds exist: `HostNode` (an element),
+`TextNode`, `FragmentNode`, `TemplateNode` (a static skeleton with dynamic holes, emitted by the
+[compiler plugin](/docs/compiler-plugin)), and `ClientRef`
+(a [server-component island](/docs/server-components)).
 
 ## Primitives
+
+<!-- code: kinetica-runtime/src/HostDsl.kt (host, column, row, text, button, textInput, checkbox), kinetica-runtime/src/Html.kt (isSafeHtmlAttributeValue, SafeUrlSchemes), kinetica-browser/src/BrowserMapping.kt -->
 
 ```kotlin
 host("section", props = mapOf("class" to "card", "id" to "intro")) { … }
@@ -28,11 +34,15 @@ like `javascript:` never reach the DOM, on the server serializer and the browser
 
 ## Styling
 
+<!-- code: kinetica-browser/src@js/BrowserKineticaApp.kt (applyFlex) -->
+
 There is no styling system in core — set `class`/`style` props and ship CSS. `row`/`column` own
 their inline `style` (flex layout); use `class` on them, or plain `host("div")` when you want
 full control.
 
 ## Semantics
+
+<!-- code: kinetica-runtime/src/Semantics.kt (Semantics, Role), kinetica-runtime/src/SemanticsTree.kt, kinetica-browser/src@js/BrowserKineticaApp.kt (Semantics.applyTo) -->
 
 Accessibility and testability are one model, carried on the node:
 
@@ -42,7 +52,7 @@ button(
     semantics = Semantics(
         role = Role.Button,        // role attribute (skipped when the native tag covers it)
         label = "Save document",   // aria-label
-        testTag = "save",          // data-testid, used by tests and drivers
+        testTag = "save",          // data-testid + data-kinetica-test-tag, used by tests and drivers
         focusable = true,          // tabindex when the element isn't natively focusable
     ),
 ) { text("Save") }
@@ -57,6 +67,8 @@ semantics tree derives its label from the text value for queries; pass an explic
 `Semantics(label = ...)` only when the accessible label differs from the visible text.
 
 ## Contexts
+
+<!-- code: kinetica-runtime/src/ComponentScope.kt (context, provide, read), kinetica-theme/src/Theme.kt (theme, provideTheme) -->
 
 Ambient values flow through the tree without prop drilling:
 
@@ -73,6 +85,8 @@ The [theme battery](/docs/persist) is built on exactly this: `provideTheme(DarkT
 
 ## Boundaries in the tree
 
+<!-- code: kinetica-runtime/src/Boundary.kt (errorBoundary, loadingBoundary) -->
+
 Two structural components manage failure and loading around any subtree — they compose with
 everything above and are covered in [Resources & boundaries](/docs/resources):
 
@@ -81,7 +95,12 @@ errorBoundary(fallback = { error, info, retry -> … }) { RiskyPanel() }
 loadingBoundary(fallback = { text("Loading…") }) { ProfileCard() }
 ```
 
+`loadingBoundary` also takes `retainPrevious: Boolean = true` — while a refresh is pending it
+keeps showing the previous content instead of flashing the fallback.
+
 ## Conditional subtrees
+
+<!-- code: kinetica-runtime/src/ComponentScope.kt (keyed, keyedRegion) -->
 
 Plain `if/else` just works: slot identity is the call site, so the two arms can never share
 or corrupt each other's state — each branch's `state`/effects live in their own slots, and

--- a/docs/verify-docs.mjs
+++ b/docs/verify-docs.mjs
@@ -86,8 +86,11 @@ try {
     if (!res.ok) throw new Error(`/docs/${slug} -> ${res.status}`);
     const body = await res.text();
     if (!body.includes("<h1>")) throw new Error(`/docs/${slug} has no h1`);
+    if (body.includes("&lt;!-- code:") || body.includes("code: kinetica-")) {
+      throw new Error(`/docs/${slug} leaks a source-link comment into the rendered page`);
+    }
   }
-  console.log(`OK   ${slugs.length + 1} pages server-render`);
+  console.log(`OK   ${slugs.length + 1} pages server-render, source-link comments stay invisible`);
 
   const demoHtml = await fetch(`${base}/examples/server-components`).then((r) => r.text());
   await verifyStaticAsset(extractAsset(home, /href="([^"]*\/assets\/site\.css\?hash=[0-9a-f]+)"/, "site.css"));
@@ -151,6 +154,43 @@ try {
     stack, { timeout: 10_000 },
   );
   console.log("OK   resource-fetch example loads per-session data, surfaces the backend NPE, retries clean");
+
+  // live example: effect-timer ticks while running and stops cleanly
+  const timer = '[data-example="effect-timer"]';
+  await page.goto(`${base}/docs/effects`, { waitUntil: "networkidle" });
+  await page.waitForSelector(`${timer} [data-testid="timer-toggle"]`, { timeout: 10_000 });
+  await page.click(`${timer} [data-testid="timer-toggle"]`);
+  await page.waitForFunction(
+    (sel) => {
+      const value = document.querySelector(`${sel} .ex-value`)?.textContent ?? "";
+      return value !== "0.0s" && /\ds$/.test(value);
+    },
+    timer, { timeout: 10_000 },
+  );
+  await page.click(`${timer} [data-testid="timer-toggle"]`);
+  const stoppedAt = await page.$eval(`${timer} .ex-value`, (n) => n.textContent);
+  await page.waitForTimeout(400);
+  const stillAt = await page.$eval(`${timer} .ex-value`, (n) => n.textContent);
+  if (stoppedAt !== stillAt) throw new Error(`timer kept ticking after stop: ${stoppedAt} -> ${stillAt}`);
+  console.log("OK   effect-timer example ticks via watch and stops on cancel");
+
+  // live example: form-signup validates then submits
+  const form = '[data-example="form-signup"]';
+  await page.goto(`${base}/docs/forms`, { waitUntil: "networkidle" });
+  await page.waitForSelector(`${form} [data-testid="signup-submit"]`, { timeout: 10_000 });
+  await page.click(`${form} [data-testid="signup-submit"]`);
+  await page.waitForFunction(
+    (sel) => document.querySelector(sel)?.textContent?.includes("Required"),
+    form, { timeout: 10_000 },
+  );
+  await page.fill(`${form} [data-testid="signup-email"]`, "ada@lovelace.dev");
+  await page.fill(`${form} [data-testid="signup-password"]`, "analytical-engine");
+  await page.click(`${form} [data-testid="signup-submit"]`);
+  await page.waitForFunction(
+    (sel) => document.querySelector(sel)?.textContent?.includes("Signed up"),
+    form, { timeout: 10_000 },
+  );
+  console.log("OK   form-signup example blocks invalid submits and accepts valid ones");
 
   // server-components demo: hydration island + typed action + stream
   await page.goto(`${base}/examples/server-components`, { waitUntil: "networkidle" });

--- a/kinetica-markdown/src/Markdown.kt
+++ b/kinetica-markdown/src/Markdown.kt
@@ -57,6 +57,11 @@ public fun parseMarkdown(source: String): List<MdBlock> {
                 blocks += MdCodeBlock(language, code.toString().trimEnd('\n'))
             }
 
+            trimmed.startsWith("<!--") -> {
+                while (index < lines.size && !lines[index].contains("-->")) index++
+                if (index < lines.size) index++ // consume the line closing the comment
+            }
+
             trimmed.startsWith(":::") -> {
                 val body = trimmed.removePrefix(":::").trim()
                 if (body.isNotEmpty()) {
@@ -129,6 +134,7 @@ public fun parseMarkdown(source: String): List<MdBlock> {
                     val nextTrimmed = next.trim()
                     val continues = nextTrimmed.isNotEmpty() &&
                         !nextTrimmed.startsWith("```") &&
+                        !nextTrimmed.startsWith("<!--") &&
                         !nextTrimmed.startsWith(":::") &&
                         !nextTrimmed.startsWith(">") &&
                         headingLevel(nextTrimmed) == 0 &&

--- a/kinetica-markdown/test/MarkdownTest.kt
+++ b/kinetica-markdown/test/MarkdownTest.kt
@@ -444,6 +444,25 @@ class MarkdownTest {
     }
 
     @Test
+    fun htmlCommentsRenderNothing() {
+        val html = render(
+            """
+            Before.
+            <!-- code: kinetica-runtime/src/ComponentScope.kt -->
+
+            <!-- a comment
+            spanning several lines -->
+            After.
+            """.trimIndent(),
+        )
+        assertTrue("<p>Before.</p>" in html, html)
+        assertTrue("<p>After.</p>" in html, html)
+        assertTrue("code:" !in html, html)
+        assertTrue("spanning" !in html, html)
+        assertTrue("&lt;!--" !in html, html)
+    }
+
+    @Test
     fun plainTextAndSlugs() {
         val inlines = parseInlines("Using **state** and `derived`!")
         assertEquals("Using state and derived!", plainText(inlines))


### PR DESCRIPTION
## What

Full refresh of the documentation site against the merged plugin-only slot model (#1), plus the fix for the failing `Docs image` workflow on main.

### Docs audited and corrected (all 18 pages)

Every page was checked claim-by-claim and snippet-by-snippet against the current code. Fixed drift:

- **getting-started**: the minimal `module.yaml` was missing `apply: common.module-template.yaml` — as written the app throws `MissingKineticaPluginException` at runtime.
- **compiler-plugin**: stale plugin version 0.1.0 → 0.3.0; psi source-generation scoped as opt-in; new "IR passes" section (template extraction, hoisting, skippable, frames) and the `transforms`/`checks` options.
- **performance**: table rebuilt from `bench/results/results.json` (current run: geomean 1.24× vs per-op fastest, **0.969× head-to-head vs React**, startup 24.5 ms / 85 KB gz); retired `perf-rewrite-design.md` pointer now points at `plan.md`; the open 5.7 MB memory-gate item stated. Stale headline in `bench/README.md` refreshed too.
- **server-components**: `toServerRenderStream` returns a `List<ServerRenderChunk>` (not a Flow); NDJSON framing is the caller's.
- **persist**: save/restore snippet used a non-existent `ComponentScope.render`; rewritten to the real `ComponentScope(runtime)` + `runtime.render(scope)` pattern; `JsonSlotPersistenceBackend` framed honestly as the in-memory reference backend.
- **router**: `NavDirection` has five values; `parseDeepLink` returns `DeepLink<R>`.
- **state/effects/ui-dsl/index**: contexts are not cells; the watch-loop guard and journal are debug-scoped; `TemplateNode` added to the node-kind list; `enabled`→`disabled` attribute mapping and `textContent` text patching described accurately; `ordinal` injection convention noted once.

### Every section linked to its code

Each section now carries an HTML comment under its heading — `<!-- code: kinetica-runtime/src/ComponentScope.kt (state, derived) -->`. `kinetica-markdown` learned to skip HTML comments (previously they'd render as escaped text), with a parser test. Convention documented in `docs/README.md`.

### Runnable examples, verified

Two new live examples: **effect-timer** on Effects (watch cancellation; driven by an interval pump since `awaitIdle` waits for full quiescence) and **form-signup** on Forms (kinetica-forms validation + submit). `docs/verify-docs.mjs` now drives all six examples in a real browser and asserts no source-link comment leaks into rendered HTML — full run green.

### CI fix (failing `Docs image` run)

https://github.com/Heapy/kinetica/actions/runs/28827198380 fails because `docker-build.sh` packages docs-site without the mandatory `kinetica-compiler:0.3.0` in mavenLocal. The script now publishes it first (covers CI and local runs); `STAGE_ONLY=1 ./docs/docker-build.sh` verified locally.

## Verification

- `./kotlin test -m kinetica-markdown --platform jvm` — 21/21 (incl. new comment test)
- `./kotlin test -m docs-site --platform jvm` — 4/4
- `node scripts/bundle-docs.mjs` + `DOCS_BASE_URL=… node docs/verify-docs.mjs` — all checks green
- `STAGE_ONLY=1 ./docs/docker-build.sh` — stages successfully

## Note for in-flight work

The frame-ordinals branch carries unpushed doc edits (KNT-0008 `text()` semantics paragraph in ui-dsl.md). This PR leaves that paragraph untouched (it documents main as it is today) and adopts the branch's exact wording for the performance.md pointer paragraph, so both merge cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)