### PR TITLE
Add Compose HTML to the framework benchmark

### DIFF
--- a/bench/README.md
+++ b/bench/README.md
@@ -83,6 +83,18 @@ bundles/minifies the linked Kotlin/JS graph into
 `part-kinetica-preplugin-before.json` snapshots the last pre-plugin numbers. Renderer work:
 see git history for the retired `perf-rewrite-design.md`; compiler work: `../compiler-perf-design.md`.
 
+The Compose HTML app lives at `../samples/browser-bench-compose/` (module
+`browser-bench-compose`, plain Kotlin/JS + JetBrains Compose Multiplatform's DOM library
+— `org.jetbrains.compose.html:html-core` — no Kinetica compiler plugin involved), built
+through `build-compose.mjs`: runs `../kotlin build -m browser-bench-compose`, then esbuild
+bundles/minifies the linked output into
+`../build/tasks/_browser-bench-compose_bundle/browser-bench-compose.bundle.mjs`. Table app
+at `../samples/browser-bench-compose/web/index.html`, tree app at the same page with
+`?app=tree`. It's the one framework here that isn't hand-tuned for this workload — general-
+purpose Compose Multiplatform runtime (slot-table composition, snapshot state) rather than a
+web-specific fine-grained or vdom renderer — and its numbers reflect that (see Interpreting
+results below).
+
 ## What is measured
 
 ### Main suite (driver/bench.mjs)
@@ -115,6 +127,13 @@ end of the last `Paint`/`Commit` event. Not wall-clock around the click — it i
 flushes, layout and paint. Headless "Chrome for Testing", no CPU throttling by default.
 **GC time** per sample is the summed duration of `MinorGC`/`MajorGC`/`V8.GC*`/`BlinkGC.*`
 events inside the same measured window (`gcMedianMs`/`gcMaxMs`/`gcMeanCount` per op).
+The post-click settle before `stopTracing()` (`measureTracedClick` in `driver/common.mjs`) is
+700ms, and Playwright's default per-action timeout is set to 180s (`openPage`) — both were
+widened from tighter defaults (280ms / 30s) when compose-web's heavier GC pressure and (on the
+10k ops) synchronous reconciliation cost pushed past them; both changes are global, so they
+cost fast frameworks nothing (they already paint and click well inside the old limits) and
+don't change any already-recorded duration, since the extra time is dead time after what's
+actually measured, not part of it.
 
 Also collected per framework:
 
@@ -245,9 +264,10 @@ Example: adding Solid.
    framework lands between vanilla ~1× and React ~1.3× on the geomean; if you see 10×+ on
    partial ops, the implementation probably isn't keyed or is in dev mode).
 
-For a framework whose app lives outside `bench/` (like Kinetica): host the page anywhere under
-the repo root, include the `__mountMs` snippet in its HTML (copy from
-`../samples/browser-bench/web/index.html`), and declare a `build` command in its config entry.
+For a framework whose app lives outside `bench/` (like Kinetica, or Compose HTML in
+`../samples/browser-bench-compose/`): host the page anywhere under the repo root, include the
+`__mountMs` snippet in its HTML (copy from `../samples/browser-bench/web/index.html`), and
+declare a `build` command in its config entry.
 
 ## Environment assumptions (things that break silently)
 
@@ -287,6 +307,26 @@ the repo root, include the `__mountMs` snippet in its HTML (copy from
   (`../kotlin test -m kinetica-runtime --platform jvm`,
   `node ../build/tasks/_kinetica-browser_linkJsTest/kinetica-browser_test.mjs` after
   `../kotlin build -m kinetica-browser`).
+- **Compose HTML context** (`html-core` 1.11.1, latest stable at time of writing; 2026-07-07
+  run, samples=5/warmup=1 — noisier than the standard 10/3 but the medians are stable):
+  single-row ops that Compose can skip via row-level memoization are competitive (select-1k
+  10 ms, select-10k 25 ms, update-10th-1k 13 ms) — confirming `RowItem` in
+  `browser-bench-compose/src/main.kt` is correctly extracted as its own skippable composable
+  (inlining row markup into the list loop instead defeats recomposition scoping entirely and
+  is much slower; don't regress that). Full-list ops are markedly heavier than every other
+  framework (run-1k 238 ms, create-10k 8.0 s) from Compose Multiplatform's general-purpose
+  slot-table/snapshot overhead per composable — expected, it's not a web-specific
+  fine-grained or vdom renderer. The striking result is medial reorder/remove on large lists:
+  swap-1k 562 ms and remove-1k 522 ms (vs. low tens of ms for every other framework), scaling
+  to swap-10k 9.6 s and **remove-10k 49.6 s** — not proportional to the ~997-row affected
+  range (constant across the 1k/10k cases per the op contract), which points to Compose's
+  default `for`+`key()` reconciliation re-walking/diffing the whole list rather than doing an
+  LIS-style minimal-move patch. This is exactly the accidental-O(n²) signal ops 10–13 are
+  designed to surface (see "What is measured" above), not an artifact of this implementation
+  — there's no lower-level Compose HTML list primitive that would avoid it while staying
+  idiomatic. It's also why `measureTracedClick`'s settle and Playwright's action timeout were
+  widened (see Timing methodology above): remove-10k's ~50s runs
+  synchronously inside the click dispatch, well past the old 30s default.
 - **Bench on AC power only.** Below ~10% battery, macOS low-power throttling delays every
   headless-Chrome paint to ~2 vsyncs (~30 ms) — for every framework — and every partial op
   reads as ~30 ms with suspiciously tight stddev. Verify the environment with a quick canary

--- a/bench/build-compose.mjs
+++ b/bench/build-compose.mjs
@@ -1,0 +1,38 @@
+import { existsSync, mkdirSync, readFileSync } from "node:fs";
+import { gzipSync } from "node:zlib";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { build } from "esbuild";
+import { run } from "../scripts/lib/run.mjs";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const repoRoot = join(here, "..");
+const linkEntry = join(repoRoot, "build", "tasks", "_browser-bench-compose_linkJs", "browser-bench-compose.mjs");
+const bundleDir = join(repoRoot, "build", "tasks", "_browser-bench-compose_bundle");
+const bundleFile = join(bundleDir, "browser-bench-compose.bundle.mjs");
+
+const kotlin = process.platform === "win32" ? "kotlin.bat" : "./kotlin";
+run(kotlin, ["build", "-m", "browser-bench-compose"], { cwd: repoRoot });
+
+if (!existsSync(linkEntry)) {
+  throw new Error(`Kotlin JS link output not found: ${linkEntry}`);
+}
+
+mkdirSync(bundleDir, { recursive: true });
+await build({
+  entryPoints: [linkEntry],
+  bundle: true,
+  minify: true,
+  treeShaking: true,
+  legalComments: "none",
+  format: "esm",
+  platform: "browser",
+  target: "es2020",
+  outfile: bundleFile,
+  logLevel: "warning",
+});
+
+const bytes = readFileSync(bundleFile);
+console.log(
+  `built compose-web bundle: ${(bytes.length / 1024).toFixed(1)}KB raw / ${(gzipSync(bytes).length / 1024).toFixed(1)}KB gzip`,
+);

--- a/bench/driver/common.mjs
+++ b/bench/driver/common.mjs
@@ -103,6 +103,13 @@ export function makeHarness(page, fw) {
 export async function openPage(browser, url, { throttle = 0 } = {}) {
   const context = await browser.newContext({ viewport: { width: 1280, height: 900 } });
   const page = await context.newPage();
+  // Default 30s is an automation safety guard, not part of the measured duration (that
+  // comes from Chrome trace timestamps) — widened so a framework whose click handler
+  // runs synchronously for a long time (e.g. O(n^2)-class reconciliation surfacing on
+  // the 10k ops, exactly what those ops are designed to catch) gets recorded rather than
+  // aborting the run. Applied to every framework; frameworks that return in milliseconds
+  // are unaffected.
+  page.setDefaultTimeout(180_000);
   const pageErrors = [];
   page.on("pageerror", (e) => pageErrors.push(e.message));
   if (throttle > 1) {
@@ -241,7 +248,13 @@ export function logLogSlope(xs, ys) {
 }
 
 // One traced, measured click: starts tracing, runs action(), awaits wait(), returns
-// parseTrace output. The 60/280ms settles mirror the original bench.mjs timing.
+// parseTrace output. The 60ms lead-in mirrors the original bench.mjs timing. The
+// post-wait settle was widened from 280ms to 700ms (2026-07-07, added for compose-web):
+// a GC-heavy framework can legitimately push the browser's actual Paint several hundred
+// ms past when the DOM assertion resolves (concurrent major GC competing with the
+// compositor), and 280ms was tight enough to misreport that as "no paint after click"
+// rather than recording the (large, real) duration. Applied uniformly to every
+// framework — negligible cost for frameworks that already paint within tens of ms.
 export async function measureTracedClick(browser, page, action, wait) {
   await browser.startTracing(page, {
     screenshots: false,
@@ -250,7 +263,7 @@ export async function measureTracedClick(browser, page, action, wait) {
   await page.waitForTimeout(60);
   await action();
   await wait();
-  await page.waitForTimeout(280);
+  await page.waitForTimeout(700);
   const trace = await browser.stopTracing();
   return parseTrace(trace);
 }

--- a/bench/frameworks.config.mjs
+++ b/bench/frameworks.config.mjs
@@ -70,10 +70,20 @@ export const frameworks = [
     rowControl: "a",
     version: "n/a",
   },
+  {
+    name: "compose-web",
+    label: "Compose HTML",
+    url: "/samples/browser-bench-compose/web/index.html",
+    treeUrl: "/samples/browser-bench-compose/web/index.html?app=tree",
+    buttons: "id",
+    rowControl: "a",
+    version: "1.11.1",
+    build: { cmd: process.execPath, args: ["bench/build-compose.mjs"] },
+  },
 ];
 
 // Validated categorical palette (dataviz reference, light/dark pairs), assigned by
-// config position. 8 slots available; 6 in use.
+// config position. 8 slots available; 7 in use.
 export const paletteSlots = [
   ["#2a78d6", "#3987e5"], // blue
   ["#1baf7a", "#199e70"], // aqua

--- a/bench/report/index.html
+++ b/bench/report/index.html
@@ -18,6 +18,7 @@
   --c-vue: #008300;
   --c-svelte: #4a3aa7;
   --c-vanilla: #e34948;
+  --c-compose-web: #e87ba4;
 }
 @media (prefers-color-scheme: dark) {
   :root {
@@ -37,6 +38,7 @@
   --c-vue: #008300;
   --c-svelte: #9085e9;
   --c-vanilla: #e66767;
+  --c-compose-web: #d55181;
   }
 }
 :root[data-theme="dark"] {
@@ -56,6 +58,7 @@
   --c-vue: #008300;
   --c-svelte: #9085e9;
   --c-vanilla: #e66767;
+  --c-compose-web: #d55181;
 }
 :root[data-theme="light"] {
   --page: #f9f9f7;
@@ -74,6 +77,7 @@
   --c-vue: #008300;
   --c-svelte: #4a3aa7;
   --c-vanilla: #e34948;
+  --c-compose-web: #e87ba4;
 }
   [data-fw="kinetica"] { --series: var(--c-kinetica); }
   [data-fw="react"] { --series: var(--c-react); }
@@ -81,6 +85,7 @@
   [data-fw="vue"] { --series: var(--c-vue); }
   [data-fw="svelte"] { --series: var(--c-svelte); }
   [data-fw="vanilla"] { --series: var(--c-vanilla); }
+  [data-fw="compose-web"] { --series: var(--c-compose-web); }
 
 * { box-sizing: border-box; }
 body {
@@ -223,7 +228,7 @@ footer { margin-top: 48px; color: var(--muted); font-size: 12.5px; }
       <span class="chip">10 samples + 3 warmup / op</span>
 
     </div>
-    <div class="legend"><span class="legend-item"><span class="swatch" data-fw="kinetica"></span>Kinetica<span class="ver"> dev</span></span><span class="legend-item"><span class="swatch" data-fw="react"></span>React<span class="ver"> 19.2.7</span></span><span class="legend-item"><span class="swatch" data-fw="preact"></span>Preact<span class="ver"> 10.29.4</span></span><span class="legend-item"><span class="swatch" data-fw="vue"></span>Vue<span class="ver"> 3.5.39</span></span><span class="legend-item"><span class="swatch" data-fw="svelte"></span>Svelte<span class="ver"> 5.56.4</span></span><span class="legend-item"><span class="swatch" data-fw="vanilla"></span>Vanilla JS<span class="ver"></span></span></div>
+    <div class="legend"><span class="legend-item"><span class="swatch" data-fw="kinetica"></span>Kinetica<span class="ver"> dev</span></span><span class="legend-item"><span class="swatch" data-fw="react"></span>React<span class="ver"> 19.2.7</span></span><span class="legend-item"><span class="swatch" data-fw="preact"></span>Preact<span class="ver"> 10.29.4</span></span><span class="legend-item"><span class="swatch" data-fw="vue"></span>Vue<span class="ver"> 3.5.39</span></span><span class="legend-item"><span class="swatch" data-fw="svelte"></span>Svelte<span class="ver"> 5.56.4</span></span><span class="legend-item"><span class="swatch" data-fw="vanilla"></span>Vanilla JS<span class="ver"></span></span><span class="legend-item"><span class="swatch" data-fw="compose-web"></span>Compose HTML<span class="ver"> 1.11.1</span></span></div>
   </header>
 
   <section>
@@ -237,33 +242,38 @@ footer { margin-top: 48px; color: var(--muted); font-size: 12.5px; }
     <div class="bars" data-unit="×">
       <div class="bar-row" data-tip="Svelte: 1.03× the per-operation fastest, geometric mean over 13 operations">
         <span class="bar-name">Svelte</span>
-        <span class="bar-track"><span class="bar" data-fw="svelte" style="width:69.3%"></span>
+        <span class="bar-track"><span class="bar" data-fw="svelte" style="width:5.1%"></span>
         <span class="bar-value">1.03×</span></span>
       </div>
       <div class="bar-row" data-tip="Vanilla JS: 1.04× the per-operation fastest, geometric mean over 13 operations">
         <span class="bar-name">Vanilla JS</span>
-        <span class="bar-track"><span class="bar" data-fw="vanilla" style="width:70.0%"></span>
+        <span class="bar-track"><span class="bar" data-fw="vanilla" style="width:5.2%"></span>
         <span class="bar-value">1.04×</span></span>
       </div>
       <div class="bar-row" data-tip="Preact: 1.12× the per-operation fastest, geometric mean over 13 operations">
         <span class="bar-name">Preact</span>
-        <span class="bar-track"><span class="bar" data-fw="preact" style="width:75.5%"></span>
+        <span class="bar-track"><span class="bar" data-fw="preact" style="width:5.6%"></span>
         <span class="bar-value">1.12×</span></span>
       </div>
       <div class="bar-row" data-tip="Kinetica: 1.24× the per-operation fastest, geometric mean over 13 operations">
         <span class="bar-name">Kinetica</span>
-        <span class="bar-track"><span class="bar" data-fw="kinetica" style="width:83.3%"></span>
+        <span class="bar-track"><span class="bar" data-fw="kinetica" style="width:6.2%"></span>
         <span class="bar-value">1.24×</span></span>
       </div>
       <div class="bar-row" data-tip="Vue: 1.24× the per-operation fastest, geometric mean over 13 operations">
         <span class="bar-name">Vue</span>
-        <span class="bar-track"><span class="bar" data-fw="vue" style="width:83.4%"></span>
+        <span class="bar-track"><span class="bar" data-fw="vue" style="width:6.2%"></span>
         <span class="bar-value">1.24×</span></span>
       </div>
       <div class="bar-row" data-tip="React: 1.28× the per-operation fastest, geometric mean over 13 operations">
         <span class="bar-name">React</span>
-        <span class="bar-track"><span class="bar" data-fw="react" style="width:86.0%"></span>
+        <span class="bar-track"><span class="bar" data-fw="react" style="width:6.4%"></span>
         <span class="bar-value">1.28×</span></span>
+      </div>
+      <div class="bar-row" data-tip="Compose HTML: 17.21× the per-operation fastest, geometric mean over 13 operations">
+        <span class="bar-name">Compose HTML</span>
+        <span class="bar-track"><span class="bar" data-fw="compose-web" style="width:86.0%"></span>
+        <span class="bar-value">17.21×</span></span>
       </div></div>
 
   </figure></div>
@@ -279,48 +289,54 @@ footer { margin-top: 48px; color: var(--muted); font-size: 12.5px; }
     <div class="table-scroll">
       <table class="results">
         <thead>
-          <tr><th></th><th scope="col"><span class="swatch" data-fw="kinetica"></span>Kinetica</th><th scope="col"><span class="swatch" data-fw="react"></span>React</th><th scope="col"><span class="swatch" data-fw="preact"></span>Preact</th><th scope="col"><span class="swatch" data-fw="vue"></span>Vue</th><th scope="col"><span class="swatch" data-fw="svelte"></span>Svelte</th><th scope="col"><span class="swatch" data-fw="vanilla"></span>Vanilla JS</th></tr>
+          <tr><th></th><th scope="col"><span class="swatch" data-fw="kinetica"></span>Kinetica</th><th scope="col"><span class="swatch" data-fw="react"></span>React</th><th scope="col"><span class="swatch" data-fw="preact"></span>Preact</th><th scope="col"><span class="swatch" data-fw="vue"></span>Vue</th><th scope="col"><span class="swatch" data-fw="svelte"></span>Svelte</th><th scope="col"><span class="swatch" data-fw="vanilla"></span>Vanilla JS</th><th scope="col"><span class="swatch" data-fw="compose-web"></span>Compose HTML</th></tr>
         </thead>
         <tbody>
-          <tr><th scope="row">create 1,000 rows</th><td class="cell" style="--cell:#86b6ef" data-dark="false"
+          <tr><th scope="row">create 1,000 rows</th><td class="cell" style="--cell:#b7d3f6" data-dark="false"
           title="Kinetica · create 1,000 rows: median 34.9ms (mean 36.5 ± 6.9, min 28.7, max 52.3, n=10)">
-          <span class="ms">34.9</span><span class="factor">1.4×</span></td><td class="cell" style="--cell:#86b6ef" data-dark="false"
+          <span class="ms">34.9</span><span class="factor">1.4×</span></td><td class="cell" style="--cell:#cde2fb" data-dark="false"
           title="React · create 1,000 rows: median 33.5ms (mean 32.8 ± 5.1, min 23.2, max 39.6, n=10)">
-          <span class="ms">33.5</span><span class="factor">1.3×</span></td><td class="cell" style="--cell:#86b6ef" data-dark="false"
+          <span class="ms">33.5</span><span class="factor">1.3×</span></td><td class="cell" style="--cell:#cde2fb" data-dark="false"
           title="Preact · create 1,000 rows: median 32.6ms (mean 34.7 ± 4.9, min 28.9, max 42.1, n=10)">
-          <span class="ms">32.6</span><span class="factor">1.3×</span></td><td class="cell" style="--cell:#6da7ec" data-dark="false"
+          <span class="ms">32.6</span><span class="factor">1.3×</span></td><td class="cell" style="--cell:#b7d3f6" data-dark="false"
           title="Vue · create 1,000 rows: median 36.1ms (mean 32.7 ± 5.8, min 22.4, max 38.9, n=10)">
           <span class="ms">36.1</span><span class="factor">1.4×</span></td><td class="cell" style="--cell:#cde2fb" data-dark="false"
           title="Svelte · create 1,000 rows: median 26.3ms (mean 27.1 ± 4.9, min 20.7, max 33.9, n=10)">
           <span class="ms">26.3</span><span class="factor">1.0×</span></td><td class="cell" style="--cell:#cde2fb" data-dark="false"
           title="Vanilla JS · create 1,000 rows: median 25.5ms (mean 27.2 ± 5.3, min 20.9, max 35.0, n=10)">
-          <span class="ms">25.5</span><span class="factor">1.0×</span></td></tr><tr><th scope="row">replace all 1,000 rows</th><td class="cell" style="--cell:#b7d3f6" data-dark="false"
+          <span class="ms">25.5</span><span class="factor">1.0×</span></td><td class="cell" style="--cell:#6da7ec" data-dark="false"
+          title="Compose HTML · create 1,000 rows: median 237.7ms (mean 238.2 ± 11.2, min 222.6, max 251.4, n=5, gc 59.3ms)">
+          <span class="ms">237.7</span><span class="factor">9.3×</span></td></tr><tr><th scope="row">replace all 1,000 rows</th><td class="cell" style="--cell:#cde2fb" data-dark="false"
           title="Kinetica · replace all 1,000 rows: median 33.6ms (mean 35.1 ± 5.0, min 29.2, max 44.6, n=10)">
-          <span class="ms">33.6</span><span class="factor">1.1×</span></td><td class="cell" style="--cell:#9ec5f4" data-dark="false"
+          <span class="ms">33.6</span><span class="factor">1.1×</span></td><td class="cell" style="--cell:#cde2fb" data-dark="false"
           title="React · replace all 1,000 rows: median 37.4ms (mean 36.4 ± 2.7, min 30.7, max 39.3, n=10)">
-          <span class="ms">37.4</span><span class="factor">1.2×</span></td><td class="cell" style="--cell:#b7d3f6" data-dark="false"
+          <span class="ms">37.4</span><span class="factor">1.2×</span></td><td class="cell" style="--cell:#cde2fb" data-dark="false"
           title="Preact · replace all 1,000 rows: median 33.2ms (mean 35.7 ± 5.8, min 28.7, max 43.6, n=10)">
-          <span class="ms">33.2</span><span class="factor">1.1×</span></td><td class="cell" style="--cell:#b7d3f6" data-dark="false"
+          <span class="ms">33.2</span><span class="factor">1.1×</span></td><td class="cell" style="--cell:#cde2fb" data-dark="false"
           title="Vue · replace all 1,000 rows: median 34.2ms (mean 31.6 ± 5.2, min 23.8, max 38.4, n=10)">
           <span class="ms">34.2</span><span class="factor">1.1×</span></td><td class="cell" style="--cell:#cde2fb" data-dark="false"
           title="Svelte · replace all 1,000 rows: median 31.4ms (mean 31.1 ± 3.4, min 24.8, max 35.0, n=10)">
           <span class="ms">31.4</span><span class="factor">1.0×</span></td><td class="cell" style="--cell:#cde2fb" data-dark="false"
           title="Vanilla JS · replace all 1,000 rows: median 32.6ms (mean 32.3 ± 2.7, min 25.7, max 36.0, n=10)">
-          <span class="ms">32.6</span><span class="factor">1.0×</span></td></tr><tr><th scope="row">partial update (every 10th row)</th><td class="cell" style="--cell:#b7d3f6" data-dark="false"
+          <span class="ms">32.6</span><span class="factor">1.0×</span></td><td class="cell" style="--cell:#6da7ec" data-dark="false"
+          title="Compose HTML · replace all 1,000 rows: median 362.0ms (mean 364.9 ± 12.2, min 354.4, max 388.2, n=5, gc 76.4ms)">
+          <span class="ms">362.0</span><span class="factor">11.5×</span></td></tr><tr><th scope="row">partial update (every 10th row)</th><td class="cell" style="--cell:#cde2fb" data-dark="false"
           title="Kinetica · partial update (every 10th row): median 8.0ms (mean 8.0 ± 0.7, min 6.3, max 9.2, n=10)">
           <span class="ms">8.0</span><span class="factor">1.1×</span></td><td class="cell" style="--cell:#cde2fb" data-dark="false"
           title="React · partial update (every 10th row): median 7.0ms (mean 6.7 ± 1.0, min 4.7, max 8.0, n=10)">
-          <span class="ms">7.0</span><span class="factor">1.0×</span></td><td class="cell" style="--cell:#b7d3f6" data-dark="false"
+          <span class="ms">7.0</span><span class="factor">1.0×</span></td><td class="cell" style="--cell:#cde2fb" data-dark="false"
           title="Preact · partial update (every 10th row): median 7.6ms (mean 7.4 ± 0.9, min 5.3, max 8.4, n=10)">
-          <span class="ms">7.6</span><span class="factor">1.1×</span></td><td class="cell" style="--cell:#9ec5f4" data-dark="false"
+          <span class="ms">7.6</span><span class="factor">1.1×</span></td><td class="cell" style="--cell:#cde2fb" data-dark="false"
           title="Vue · partial update (every 10th row): median 8.1ms (mean 8.1 ± 0.4, min 7.6, max 9.0, n=10)">
           <span class="ms">8.1</span><span class="factor">1.2×</span></td><td class="cell" style="--cell:#cde2fb" data-dark="false"
           title="Svelte · partial update (every 10th row): median 7.2ms (mean 7.3 ± 0.8, min 5.6, max 8.2, n=10)">
-          <span class="ms">7.2</span><span class="factor">1.0×</span></td><td class="cell" style="--cell:#b7d3f6" data-dark="false"
+          <span class="ms">7.2</span><span class="factor">1.0×</span></td><td class="cell" style="--cell:#cde2fb" data-dark="false"
           title="Vanilla JS · partial update (every 10th row): median 7.6ms (mean 7.4 ± 1.2, min 5.0, max 9.6, n=10)">
-          <span class="ms">7.6</span><span class="factor">1.1×</span></td></tr><tr><th scope="row">select row</th><td class="cell" style="--cell:#b7d3f6" data-dark="false"
+          <span class="ms">7.6</span><span class="factor">1.1×</span></td><td class="cell" style="--cell:#b7d3f6" data-dark="false"
+          title="Compose HTML · partial update (every 10th row): median 12.9ms (mean 12.8 ± 1.9, min 9.6, max 15.3, n=5)">
+          <span class="ms">12.9</span><span class="factor">1.9×</span></td></tr><tr><th scope="row">select row</th><td class="cell" style="--cell:#cde2fb" data-dark="false"
           title="Kinetica · select row: median 7.8ms (mean 7.7 ± 0.5, min 6.7, max 8.4, n=10)">
-          <span class="ms">7.8</span><span class="factor">1.1×</span></td><td class="cell" style="--cell:#b7d3f6" data-dark="false"
+          <span class="ms">7.8</span><span class="factor">1.1×</span></td><td class="cell" style="--cell:#cde2fb" data-dark="false"
           title="React · select row: median 7.6ms (mean 7.3 ± 0.7, min 6.3, max 8.0, n=10)">
           <span class="ms">7.6</span><span class="factor">1.1×</span></td><td class="cell" style="--cell:#cde2fb" data-dark="false"
           title="Preact · select row: median 7.4ms (mean 7.6 ± 0.6, min 6.6, max 8.4, n=10)">
@@ -328,21 +344,25 @@ footer { margin-top: 48px; color: var(--muted); font-size: 12.5px; }
           title="Vue · select row: median 7.2ms (mean 7.2 ± 0.3, min 6.9, max 7.5, n=10)">
           <span class="ms">7.2</span><span class="factor">1.0×</span></td><td class="cell" style="--cell:#cde2fb" data-dark="false"
           title="Svelte · select row: median 7.4ms (mean 7.4 ± 0.6, min 6.3, max 8.3, n=10)">
-          <span class="ms">7.4</span><span class="factor">1.0×</span></td><td class="cell" style="--cell:#b7d3f6" data-dark="false"
+          <span class="ms">7.4</span><span class="factor">1.0×</span></td><td class="cell" style="--cell:#cde2fb" data-dark="false"
           title="Vanilla JS · select row: median 7.6ms (mean 7.4 ± 1.2, min 4.6, max 8.6, n=10)">
-          <span class="ms">7.6</span><span class="factor">1.1×</span></td></tr><tr><th scope="row">swap two rows</th><td class="cell" style="--cell:#b7d3f6" data-dark="false"
+          <span class="ms">7.6</span><span class="factor">1.1×</span></td><td class="cell" style="--cell:#b7d3f6" data-dark="false"
+          title="Compose HTML · select row: median 10.5ms (mean 10.1 ± 0.7, min 9.2, max 10.9, n=5)">
+          <span class="ms">10.5</span><span class="factor">1.5×</span></td></tr><tr><th scope="row">swap two rows</th><td class="cell" style="--cell:#cde2fb" data-dark="false"
           title="Kinetica · swap two rows: median 8.1ms (mean 8.0 ± 1.3, min 5.4, max 10.5, n=10)">
-          <span class="ms">8.1</span><span class="factor">1.1×</span></td><td class="cell" style="--cell:#0d366b" data-dark="true"
+          <span class="ms">8.1</span><span class="factor">1.1×</span></td><td class="cell" style="--cell:#9ec5f4" data-dark="false"
           title="React · swap two rows: median 22.5ms (mean 24.6 ± 4.6, min 19.9, max 33.3, n=10)">
           <span class="ms">22.5</span><span class="factor">3.1×</span></td><td class="cell" style="--cell:#cde2fb" data-dark="false"
           title="Preact · swap two rows: median 7.3ms (mean 7.2 ± 0.9, min 5.9, max 8.5, n=10)">
-          <span class="ms">7.3</span><span class="factor">1.0×</span></td><td class="cell" style="--cell:#b7d3f6" data-dark="false"
+          <span class="ms">7.3</span><span class="factor">1.0×</span></td><td class="cell" style="--cell:#cde2fb" data-dark="false"
           title="Vue · swap two rows: median 8.3ms (mean 8.3 ± 1.1, min 6.6, max 11.0, n=10)">
-          <span class="ms">8.3</span><span class="factor">1.1×</span></td><td class="cell" style="--cell:#b7d3f6" data-dark="false"
+          <span class="ms">8.3</span><span class="factor">1.1×</span></td><td class="cell" style="--cell:#cde2fb" data-dark="false"
           title="Svelte · swap two rows: median 7.8ms (mean 7.7 ± 0.5, min 6.6, max 8.6, n=10)">
           <span class="ms">7.8</span><span class="factor">1.1×</span></td><td class="cell" style="--cell:#cde2fb" data-dark="false"
           title="Vanilla JS · swap two rows: median 7.4ms (mean 7.2 ± 0.8, min 6.0, max 8.2, n=10)">
-          <span class="ms">7.4</span><span class="factor">1.0×</span></td></tr><tr><th scope="row">remove one row</th><td class="cell" style="--cell:#9ec5f4" data-dark="false"
+          <span class="ms">7.4</span><span class="factor">1.0×</span></td><td class="cell" style="--cell:#2a78d6" data-dark="true"
+          title="Compose HTML · swap two rows: median 561.8ms (mean 561.2 ± 3.2, min 555.7, max 565.6, n=5, gc 7.2ms)">
+          <span class="ms">561.8</span><span class="factor">76.7×</span></td></tr><tr><th scope="row">remove one row</th><td class="cell" style="--cell:#cde2fb" data-dark="false"
           title="Kinetica · remove one row: median 8.5ms (mean 8.5 ± 0.7, min 7.4, max 9.4, n=10)">
           <span class="ms">8.5</span><span class="factor">1.2×</span></td><td class="cell" style="--cell:#cde2fb" data-dark="false"
           title="React · remove one row: median 7.4ms (mean 7.3 ± 0.7, min 5.9, max 8.7, n=10)">
@@ -354,33 +374,39 @@ footer { margin-top: 48px; color: var(--muted); font-size: 12.5px; }
           title="Svelte · remove one row: median 7.2ms (mean 7.2 ± 0.5, min 6.2, max 7.9, n=10)">
           <span class="ms">7.2</span><span class="factor">1.0×</span></td><td class="cell" style="--cell:#cde2fb" data-dark="false"
           title="Vanilla JS · remove one row: median 7.3ms (mean 7.3 ± 0.6, min 6.2, max 8.4, n=10)">
-          <span class="ms">7.3</span><span class="factor">1.0×</span></td></tr><tr><th scope="row">create 10,000 rows</th><td class="cell" style="--cell:#6da7ec" data-dark="false"
+          <span class="ms">7.3</span><span class="factor">1.0×</span></td><td class="cell" style="--cell:#2a78d6" data-dark="true"
+          title="Compose HTML · remove one row: median 522.0ms (mean 523.8 ± 5.7, min 516.9, max 533.6, n=5, gc 7.7ms)">
+          <span class="ms">522.0</span><span class="factor">73.0×</span></td></tr><tr><th scope="row">create 10,000 rows</th><td class="cell" style="--cell:#b7d3f6" data-dark="false"
           title="Kinetica · create 10,000 rows: median 283.8ms (mean 292.7 ± 19.2, min 278.5, max 343.2, n=10, gc 151.0ms)">
-          <span class="ms">283.8</span><span class="factor">1.4×</span></td><td class="cell" style="--cell:#5598e7" data-dark="false"
+          <span class="ms">283.8</span><span class="factor">1.4×</span></td><td class="cell" style="--cell:#b7d3f6" data-dark="false"
           title="React · create 10,000 rows: median 316.0ms (mean 348.0 ± 103.0, min 295.2, max 655.8, n=10)">
-          <span class="ms">316.0</span><span class="factor">1.5×</span></td><td class="cell" style="--cell:#9ec5f4" data-dark="false"
+          <span class="ms">316.0</span><span class="factor">1.5×</span></td><td class="cell" style="--cell:#cde2fb" data-dark="false"
           title="Preact · create 10,000 rows: median 245.4ms (mean 248.7 ± 7.4, min 237.6, max 263.2, n=10, gc 51.2ms)">
-          <span class="ms">245.4</span><span class="factor">1.2×</span></td><td class="cell" style="--cell:#b7d3f6" data-dark="false"
+          <span class="ms">245.4</span><span class="factor">1.2×</span></td><td class="cell" style="--cell:#cde2fb" data-dark="false"
           title="Vue · create 10,000 rows: median 234.4ms (mean 238.2 ± 14.4, min 221.7, max 275.1, n=10, gc 25.2ms)">
           <span class="ms">234.4</span><span class="factor">1.1×</span></td><td class="cell" style="--cell:#cde2fb" data-dark="false"
           title="Svelte · create 10,000 rows: median 203.9ms (mean 206.9 ± 15.0, min 191.3, max 244.5, n=10, gc 64.5ms)">
           <span class="ms">203.9</span><span class="factor">1.0×</span></td><td class="cell" style="--cell:#cde2fb" data-dark="false"
           title="Vanilla JS · create 10,000 rows: median 206.3ms (mean 205.9 ± 7.5, min 192.6, max 216.5, n=10, gc 6.2ms)">
-          <span class="ms">206.3</span><span class="factor">1.0×</span></td></tr><tr><th scope="row">append 1,000 rows to 1,000</th><td class="cell" style="--cell:#9ec5f4" data-dark="false"
+          <span class="ms">206.3</span><span class="factor">1.0×</span></td><td class="cell" style="--cell:#3987e5" data-dark="true"
+          title="Compose HTML · create 10,000 rows: median 7,995.6ms (mean 8,010.4 ± 78.5, min 7,909.4, max 8,108.5, n=5, gc 1,346.1ms)">
+          <span class="ms">7,995.6</span><span class="factor">39.2×</span></td></tr><tr><th scope="row">append 1,000 rows to 1,000</th><td class="cell" style="--cell:#cde2fb" data-dark="false"
           title="Kinetica · append 1,000 rows to 1,000: median 34.6ms (mean 36.4 ± 4.2, min 31.7, max 42.9, n=10)">
-          <span class="ms">34.6</span><span class="factor">1.2×</span></td><td class="cell" style="--cell:#9ec5f4" data-dark="false"
+          <span class="ms">34.6</span><span class="factor">1.2×</span></td><td class="cell" style="--cell:#cde2fb" data-dark="false"
           title="React · append 1,000 rows to 1,000: median 32.8ms (mean 32.0 ± 3.8, min 25.7, max 36.4, n=10)">
-          <span class="ms">32.8</span><span class="factor">1.2×</span></td><td class="cell" style="--cell:#6da7ec" data-dark="false"
+          <span class="ms">32.8</span><span class="factor">1.2×</span></td><td class="cell" style="--cell:#b7d3f6" data-dark="false"
           title="Preact · append 1,000 rows to 1,000: median 39.3ms (mean 38.9 ± 2.2, min 35.1, max 41.3, n=10)">
-          <span class="ms">39.3</span><span class="factor">1.4×</span></td><td class="cell" style="--cell:#b7d3f6" data-dark="false"
+          <span class="ms">39.3</span><span class="factor">1.4×</span></td><td class="cell" style="--cell:#cde2fb" data-dark="false"
           title="Vue · append 1,000 rows to 1,000: median 30.9ms (mean 29.9 ± 4.1, min 23.6, max 36.1, n=10)">
-          <span class="ms">30.9</span><span class="factor">1.1×</span></td><td class="cell" style="--cell:#b7d3f6" data-dark="false"
+          <span class="ms">30.9</span><span class="factor">1.1×</span></td><td class="cell" style="--cell:#cde2fb" data-dark="false"
           title="Svelte · append 1,000 rows to 1,000: median 32.3ms (mean 30.2 ± 5.7, min 21.0, max 36.5, n=10)">
           <span class="ms">32.3</span><span class="factor">1.1×</span></td><td class="cell" style="--cell:#cde2fb" data-dark="false"
           title="Vanilla JS · append 1,000 rows to 1,000: median 28.2ms (mean 29.3 ± 5.4, min 21.0, max 35.8, n=10)">
-          <span class="ms">28.2</span><span class="factor">1.0×</span></td></tr><tr><th scope="row">clear 1,000 rows</th><td class="cell" style="--cell:#cde2fb" data-dark="false"
+          <span class="ms">28.2</span><span class="factor">1.0×</span></td><td class="cell" style="--cell:#6da7ec" data-dark="false"
+          title="Compose HTML · append 1,000 rows to 1,000: median 233.1ms (mean 234.7 ± 3.2, min 232.4, max 241.0, n=5, gc 55.8ms)">
+          <span class="ms">233.1</span><span class="factor">8.3×</span></td></tr><tr><th scope="row">clear 1,000 rows</th><td class="cell" style="--cell:#cde2fb" data-dark="false"
           title="Kinetica · clear 1,000 rows: median 7.0ms (mean 6.8 ± 0.8, min 5.5, max 7.9, n=10)">
-          <span class="ms">7.0</span><span class="factor">1.0×</span></td><td class="cell" style="--cell:#b7d3f6" data-dark="false"
+          <span class="ms">7.0</span><span class="factor">1.0×</span></td><td class="cell" style="--cell:#cde2fb" data-dark="false"
           title="React · clear 1,000 rows: median 7.2ms (mean 7.2 ± 0.4, min 6.7, max 8.0, n=10)">
           <span class="ms">7.2</span><span class="factor">1.1×</span></td><td class="cell" style="--cell:#cde2fb" data-dark="false"
           title="Preact · clear 1,000 rows: median 6.8ms (mean 6.9 ± 0.7, min 5.9, max 8.1, n=10)">
@@ -390,56 +416,66 @@ footer { margin-top: 48px; color: var(--muted); font-size: 12.5px; }
           title="Svelte · clear 1,000 rows: median 6.9ms (mean 6.8 ± 0.5, min 5.8, max 7.5, n=10)">
           <span class="ms">6.9</span><span class="factor">1.0×</span></td><td class="cell" style="--cell:#cde2fb" data-dark="false"
           title="Vanilla JS · clear 1,000 rows: median 7.0ms (mean 6.7 ± 0.9, min 5.3, max 7.6, n=10)">
-          <span class="ms">7.0</span><span class="factor">1.0×</span></td></tr><tr><th scope="row">select row (10k table)</th><td class="cell" style="--cell:#b7d3f6" data-dark="false"
+          <span class="ms">7.0</span><span class="factor">1.0×</span></td><td class="cell" style="--cell:#9ec5f4" data-dark="false"
+          title="Compose HTML · clear 1,000 rows: median 24.1ms (mean 25.6 ± 4.2, min 20.4, max 32.5, n=5)">
+          <span class="ms">24.1</span><span class="factor">3.5×</span></td></tr><tr><th scope="row">select row (10k table)</th><td class="cell" style="--cell:#cde2fb" data-dark="false"
           title="Kinetica · select row (10k table): median 8.7ms (mean 9.1 ± 1.0, min 8.1, max 11.1, n=10)">
           <span class="ms">8.7</span><span class="factor">1.1×</span></td><td class="cell" style="--cell:#cde2fb" data-dark="false"
           title="React · select row (10k table): median 7.9ms (mean 7.9 ± 0.5, min 7.1, max 8.6, n=10)">
           <span class="ms">7.9</span><span class="factor">1.0×</span></td><td class="cell" style="--cell:#cde2fb" data-dark="false"
           title="Preact · select row (10k table): median 7.9ms (mean 7.9 ± 0.2, min 7.6, max 8.3, n=10)">
-          <span class="ms">7.9</span><span class="factor">1.0×</span></td><td class="cell" style="--cell:#2a78d6" data-dark="true"
+          <span class="ms">7.9</span><span class="factor">1.0×</span></td><td class="cell" style="--cell:#b7d3f6" data-dark="false"
           title="Vue · select row (10k table): median 15.2ms (mean 15.1 ± 0.9, min 13.8, max 16.6, n=10)">
           <span class="ms">15.2</span><span class="factor">2.0×</span></td><td class="cell" style="--cell:#cde2fb" data-dark="false"
           title="Svelte · select row (10k table): median 7.7ms (mean 7.7 ± 0.6, min 6.9, max 8.6, n=10)">
           <span class="ms">7.7</span><span class="factor">1.0×</span></td><td class="cell" style="--cell:#cde2fb" data-dark="false"
           title="Vanilla JS · select row (10k table): median 7.9ms (mean 8.0 ± 0.5, min 7.5, max 8.8, n=10)">
-          <span class="ms">7.9</span><span class="factor">1.0×</span></td></tr><tr><th scope="row">swap two rows (10k table)</th><td class="cell" style="--cell:#6da7ec" data-dark="false"
+          <span class="ms">7.9</span><span class="factor">1.0×</span></td><td class="cell" style="--cell:#9ec5f4" data-dark="false"
+          title="Compose HTML · select row (10k table): median 25.0ms (mean 26.1 ± 3.8, min 21.3, max 31.5, n=5, gc 18.5ms)">
+          <span class="ms">25.0</span><span class="factor">3.2×</span></td></tr><tr><th scope="row">swap two rows (10k table)</th><td class="cell" style="--cell:#b7d3f6" data-dark="false"
           title="Kinetica · swap two rows (10k table): median 42.1ms (mean 42.6 ± 3.1, min 37.6, max 48.7, n=10)">
-          <span class="ms">42.1</span><span class="factor">1.5×</span></td><td class="cell" style="--cell:#2a78d6" data-dark="true"
+          <span class="ms">42.1</span><span class="factor">1.5×</span></td><td class="cell" style="--cell:#b7d3f6" data-dark="false"
           title="React · swap two rows (10k table): median 54.1ms (mean 53.9 ± 1.8, min 50.8, max 57.5, n=10)">
-          <span class="ms">54.1</span><span class="factor">1.9×</span></td><td class="cell" style="--cell:#9ec5f4" data-dark="false"
+          <span class="ms">54.1</span><span class="factor">1.9×</span></td><td class="cell" style="--cell:#cde2fb" data-dark="false"
           title="Preact · swap two rows (10k table): median 35.6ms (mean 36.6 ± 4.7, min 31.8, max 47.8, n=10)">
-          <span class="ms">35.6</span><span class="factor">1.3×</span></td><td class="cell" style="--cell:#6da7ec" data-dark="false"
+          <span class="ms">35.6</span><span class="factor">1.3×</span></td><td class="cell" style="--cell:#b7d3f6" data-dark="false"
           title="Vue · swap two rows (10k table): median 42.7ms (mean 42.1 ± 3.0, min 35.8, max 45.7, n=10)">
-          <span class="ms">42.7</span><span class="factor">1.5×</span></td><td class="cell" style="--cell:#b7d3f6" data-dark="false"
+          <span class="ms">42.7</span><span class="factor">1.5×</span></td><td class="cell" style="--cell:#cde2fb" data-dark="false"
           title="Svelte · swap two rows (10k table): median 30.0ms (mean 30.4 ± 2.0, min 26.0, max 33.6, n=10)">
           <span class="ms">30.0</span><span class="factor">1.1×</span></td><td class="cell" style="--cell:#cde2fb" data-dark="false"
           title="Vanilla JS · swap two rows (10k table): median 28.3ms (mean 29.0 ± 2.8, min 26.3, max 34.1, n=10)">
-          <span class="ms">28.3</span><span class="factor">1.0×</span></td></tr><tr><th scope="row">remove one row (10k table)</th><td class="cell" style="--cell:#5598e7" data-dark="false"
+          <span class="ms">28.3</span><span class="factor">1.0×</span></td><td class="cell" style="--cell:#184f95" data-dark="true"
+          title="Compose HTML · swap two rows (10k table): median 9,554.4ms (mean 9,525.2 ± 59.2, min 9,416.6, max 9,576.0, n=5, gc 83.5ms)">
+          <span class="ms">9,554.4</span><span class="factor">337.8×</span></td></tr><tr><th scope="row">remove one row (10k table)</th><td class="cell" style="--cell:#b7d3f6" data-dark="false"
           title="Kinetica · remove one row (10k table): median 59.8ms (mean 60.2 ± 10.5, min 47.6, max 75.7, n=10)">
           <span class="ms">59.8</span><span class="factor">1.5×</span></td><td class="cell" style="--cell:#cde2fb" data-dark="false"
           title="React · remove one row (10k table): median 40.3ms (mean 40.9 ± 3.8, min 36.1, max 50.5, n=10)">
-          <span class="ms">40.3</span><span class="factor">1.0×</span></td><td class="cell" style="--cell:#b7d3f6" data-dark="false"
+          <span class="ms">40.3</span><span class="factor">1.0×</span></td><td class="cell" style="--cell:#cde2fb" data-dark="false"
           title="Preact · remove one row (10k table): median 40.8ms (mean 43.1 ± 5.2, min 38.6, max 53.0, n=10)">
-          <span class="ms">40.8</span><span class="factor">1.1×</span></td><td class="cell" style="--cell:#6da7ec" data-dark="false"
+          <span class="ms">40.8</span><span class="factor">1.1×</span></td><td class="cell" style="--cell:#b7d3f6" data-dark="false"
           title="Vue · remove one row (10k table): median 53.8ms (mean 55.2 ± 5.8, min 49.1, max 71.8, n=10)">
           <span class="ms">53.8</span><span class="factor">1.4×</span></td><td class="cell" style="--cell:#cde2fb" data-dark="false"
           title="Svelte · remove one row (10k table): median 38.8ms (mean 42.1 ± 8.0, min 36.7, max 64.2, n=10)">
-          <span class="ms">38.8</span><span class="factor">1.0×</span></td><td class="cell" style="--cell:#b7d3f6" data-dark="false"
+          <span class="ms">38.8</span><span class="factor">1.0×</span></td><td class="cell" style="--cell:#cde2fb" data-dark="false"
           title="Vanilla JS · remove one row (10k table): median 44.4ms (mean 44.9 ± 7.8, min 36.2, max 57.0, n=10)">
-          <span class="ms">44.4</span><span class="factor">1.1×</span></td></tr><tr><th scope="row">partial update (every 10th of 10k)</th><td class="cell" style="--cell:#6da7ec" data-dark="false"
+          <span class="ms">44.4</span><span class="factor">1.1×</span></td><td class="cell" style="--cell:#0d366b" data-dark="true"
+          title="Compose HTML · remove one row (10k table): median 49,552.8ms (mean 49,663.2 ± 355.8, min 49,289.4, max 50,205.0, n=5, gc 384.3ms)">
+          <span class="ms">49,552.8</span><span class="factor">1,276.5×</span></td></tr><tr><th scope="row">partial update (every 10th of 10k)</th><td class="cell" style="--cell:#b7d3f6" data-dark="false"
           title="Kinetica · partial update (every 10th of 10k): median 43.3ms (mean 49.1 ± 14.2, min 37.5, max 86.2, n=10)">
-          <span class="ms">43.3</span><span class="factor">1.5×</span></td><td class="cell" style="--cell:#9ec5f4" data-dark="false"
+          <span class="ms">43.3</span><span class="factor">1.5×</span></td><td class="cell" style="--cell:#cde2fb" data-dark="false"
           title="React · partial update (every 10th of 10k): median 34.4ms (mean 34.2 ± 1.9, min 31.6, max 38.7, n=10)">
-          <span class="ms">34.4</span><span class="factor">1.2×</span></td><td class="cell" style="--cell:#9ec5f4" data-dark="false"
+          <span class="ms">34.4</span><span class="factor">1.2×</span></td><td class="cell" style="--cell:#cde2fb" data-dark="false"
           title="Preact · partial update (every 10th of 10k): median 36.6ms (mean 37.8 ± 3.3, min 33.8, max 46.4, n=10)">
-          <span class="ms">36.6</span><span class="factor">1.2×</span></td><td class="cell" style="--cell:#5598e7" data-dark="false"
+          <span class="ms">36.6</span><span class="factor">1.2×</span></td><td class="cell" style="--cell:#b7d3f6" data-dark="false"
           title="Vue · partial update (every 10th of 10k): median 45.1ms (mean 45.3 ± 2.5, min 41.3, max 50.7, n=10)">
           <span class="ms">45.1</span><span class="factor">1.5×</span></td><td class="cell" style="--cell:#cde2fb" data-dark="false"
           title="Svelte · partial update (every 10th of 10k): median 29.4ms (mean 30.6 ± 3.1, min 27.0, max 37.8, n=10)">
-          <span class="ms">29.4</span><span class="factor">1.0×</span></td><td class="cell" style="--cell:#b7d3f6" data-dark="false"
+          <span class="ms">29.4</span><span class="factor">1.0×</span></td><td class="cell" style="--cell:#cde2fb" data-dark="false"
           title="Vanilla JS · partial update (every 10th of 10k): median 32.1ms (mean 34.5 ± 4.8, min 28.6, max 43.5, n=10)">
-          <span class="ms">32.1</span><span class="factor">1.1×</span></td></tr>
-          <tr class="geo-row"><th scope="row">geometric mean of factors</th><td class="cell geo" style="--cell:#9ec5f4" data-dark="false"><span class="ms">1.24×</span></td><td class="cell geo" style="--cell:#86b6ef" data-dark="false"><span class="ms">1.28×</span></td><td class="cell geo" style="--cell:#b7d3f6" data-dark="false"><span class="ms">1.12×</span></td><td class="cell geo" style="--cell:#9ec5f4" data-dark="false"><span class="ms">1.24×</span></td><td class="cell geo" style="--cell:#cde2fb" data-dark="false"><span class="ms">1.03×</span></td><td class="cell geo" style="--cell:#cde2fb" data-dark="false"><span class="ms">1.04×</span></td></tr>
+          <span class="ms">32.1</span><span class="factor">1.1×</span></td><td class="cell" style="--cell:#9ec5f4" data-dark="false"
+          title="Compose HTML · partial update (every 10th of 10k): median 130.0ms (mean 120.8 ± 18.5, min 98.2, max 143.3, n=5, gc 29.9ms)">
+          <span class="ms">130.0</span><span class="factor">4.4×</span></td></tr>
+          <tr class="geo-row"><th scope="row">geometric mean of factors</th><td class="cell geo" style="--cell:#cde2fb" data-dark="false"><span class="ms">1.24×</span></td><td class="cell geo" style="--cell:#cde2fb" data-dark="false"><span class="ms">1.28×</span></td><td class="cell geo" style="--cell:#cde2fb" data-dark="false"><span class="ms">1.12×</span></td><td class="cell geo" style="--cell:#cde2fb" data-dark="false"><span class="ms">1.24×</span></td><td class="cell geo" style="--cell:#cde2fb" data-dark="false"><span class="ms">1.03×</span></td><td class="cell geo" style="--cell:#cde2fb" data-dark="false"><span class="ms">1.04×</span></td><td class="cell geo" style="--cell:#5598e7" data-dark="false"><span class="ms">17.21×</span></td></tr>
         </tbody>
       </table>
     </div>
@@ -518,33 +554,38 @@ footer { margin-top: 48px; color: var(--muted); font-size: 12.5px; }
     <div class="bars" data-unit="ms">
       <div class="bar-row" data-tip="Kinetica: median 34.9ms · mean 36.5 ± 6.9 · range 28.7–52.3ms · 10 samples">
         <span class="bar-name">Kinetica</span>
-        <span class="bar-track"><span class="bar" data-fw="kinetica" style="width:83.3%"></span>
+        <span class="bar-track"><span class="bar" data-fw="kinetica" style="width:12.6%"></span>
         <span class="bar-value">34.9</span></span>
       </div>
       <div class="bar-row" data-tip="React: median 33.5ms · mean 32.8 ± 5.1 · range 23.2–39.6ms · 10 samples">
         <span class="bar-name">React</span>
-        <span class="bar-track"><span class="bar" data-fw="react" style="width:79.9%"></span>
+        <span class="bar-track"><span class="bar" data-fw="react" style="width:12.1%"></span>
         <span class="bar-value">33.5</span></span>
       </div>
       <div class="bar-row" data-tip="Preact: median 32.6ms · mean 34.7 ± 4.9 · range 28.9–42.1ms · 10 samples">
         <span class="bar-name">Preact</span>
-        <span class="bar-track"><span class="bar" data-fw="preact" style="width:77.6%"></span>
+        <span class="bar-track"><span class="bar" data-fw="preact" style="width:11.8%"></span>
         <span class="bar-value">32.6</span></span>
       </div>
       <div class="bar-row" data-tip="Vue: median 36.1ms · mean 32.7 ± 5.8 · range 22.4–38.9ms · 10 samples">
         <span class="bar-name">Vue</span>
-        <span class="bar-track"><span class="bar" data-fw="vue" style="width:86.0%"></span>
+        <span class="bar-track"><span class="bar" data-fw="vue" style="width:13.1%"></span>
         <span class="bar-value">36.1</span></span>
       </div>
       <div class="bar-row" data-tip="Svelte: median 26.3ms · mean 27.1 ± 4.9 · range 20.7–33.9ms · 10 samples">
         <span class="bar-name">Svelte</span>
-        <span class="bar-track"><span class="bar" data-fw="svelte" style="width:62.6%"></span>
+        <span class="bar-track"><span class="bar" data-fw="svelte" style="width:9.5%"></span>
         <span class="bar-value">26.3</span></span>
       </div>
       <div class="bar-row" data-tip="Vanilla JS: median 25.5ms · mean 27.2 ± 5.3 · range 20.9–35.0ms · 10 samples">
         <span class="bar-name">Vanilla JS</span>
-        <span class="bar-track"><span class="bar" data-fw="vanilla" style="width:60.7%"></span>
+        <span class="bar-track"><span class="bar" data-fw="vanilla" style="width:9.2%"></span>
         <span class="bar-value">25.5</span></span>
+      </div>
+      <div class="bar-row" data-tip="Compose HTML: median 237.7ms · mean 238.2 ± 11.2 · range 222.6–251.4ms · 5 samples">
+        <span class="bar-name">Compose HTML</span>
+        <span class="bar-track"><span class="bar" data-fw="compose-web" style="width:86.0%"></span>
+        <span class="bar-value">237.7</span></span>
       </div></div>
 
   </figure>
@@ -553,33 +594,38 @@ footer { margin-top: 48px; color: var(--muted); font-size: 12.5px; }
     <div class="bars" data-unit="ms">
       <div class="bar-row" data-tip="Kinetica: median 33.6ms · mean 35.1 ± 5.0 · range 29.2–44.6ms · 10 samples">
         <span class="bar-name">Kinetica</span>
-        <span class="bar-track"><span class="bar" data-fw="kinetica" style="width:77.2%"></span>
+        <span class="bar-track"><span class="bar" data-fw="kinetica" style="width:8.0%"></span>
         <span class="bar-value">33.6</span></span>
       </div>
       <div class="bar-row" data-tip="React: median 37.4ms · mean 36.4 ± 2.7 · range 30.7–39.3ms · 10 samples">
         <span class="bar-name">React</span>
-        <span class="bar-track"><span class="bar" data-fw="react" style="width:86.0%"></span>
+        <span class="bar-track"><span class="bar" data-fw="react" style="width:8.9%"></span>
         <span class="bar-value">37.4</span></span>
       </div>
       <div class="bar-row" data-tip="Preact: median 33.2ms · mean 35.7 ± 5.8 · range 28.7–43.6ms · 10 samples">
         <span class="bar-name">Preact</span>
-        <span class="bar-track"><span class="bar" data-fw="preact" style="width:76.3%"></span>
+        <span class="bar-track"><span class="bar" data-fw="preact" style="width:7.9%"></span>
         <span class="bar-value">33.2</span></span>
       </div>
       <div class="bar-row" data-tip="Vue: median 34.2ms · mean 31.6 ± 5.2 · range 23.8–38.4ms · 10 samples">
         <span class="bar-name">Vue</span>
-        <span class="bar-track"><span class="bar" data-fw="vue" style="width:78.6%"></span>
+        <span class="bar-track"><span class="bar" data-fw="vue" style="width:8.1%"></span>
         <span class="bar-value">34.2</span></span>
       </div>
       <div class="bar-row" data-tip="Svelte: median 31.4ms · mean 31.1 ± 3.4 · range 24.8–35.0ms · 10 samples">
         <span class="bar-name">Svelte</span>
-        <span class="bar-track"><span class="bar" data-fw="svelte" style="width:72.1%"></span>
+        <span class="bar-track"><span class="bar" data-fw="svelte" style="width:7.5%"></span>
         <span class="bar-value">31.4</span></span>
       </div>
       <div class="bar-row" data-tip="Vanilla JS: median 32.6ms · mean 32.3 ± 2.7 · range 25.7–36.0ms · 10 samples">
         <span class="bar-name">Vanilla JS</span>
-        <span class="bar-track"><span class="bar" data-fw="vanilla" style="width:74.9%"></span>
+        <span class="bar-track"><span class="bar" data-fw="vanilla" style="width:7.7%"></span>
         <span class="bar-value">32.6</span></span>
+      </div>
+      <div class="bar-row" data-tip="Compose HTML: median 362.0ms · mean 364.9 ± 12.2 · range 354.4–388.2ms · 5 samples">
+        <span class="bar-name">Compose HTML</span>
+        <span class="bar-track"><span class="bar" data-fw="compose-web" style="width:86.0%"></span>
+        <span class="bar-value">362.0</span></span>
       </div></div>
 
   </figure>
@@ -588,33 +634,38 @@ footer { margin-top: 48px; color: var(--muted); font-size: 12.5px; }
     <div class="bars" data-unit="ms">
       <div class="bar-row" data-tip="Kinetica: median 8.0ms · mean 8.0 ± 0.7 · range 6.3–9.2ms · 10 samples">
         <span class="bar-name">Kinetica</span>
-        <span class="bar-track"><span class="bar" data-fw="kinetica" style="width:84.4%"></span>
+        <span class="bar-track"><span class="bar" data-fw="kinetica" style="width:52.9%"></span>
         <span class="bar-value">8.0</span></span>
       </div>
       <div class="bar-row" data-tip="React: median 7.0ms · mean 6.7 ± 1.0 · range 4.7–8.0ms · 10 samples">
         <span class="bar-name">React</span>
-        <span class="bar-track"><span class="bar" data-fw="react" style="width:73.8%"></span>
+        <span class="bar-track"><span class="bar" data-fw="react" style="width:46.3%"></span>
         <span class="bar-value">7.0</span></span>
       </div>
       <div class="bar-row" data-tip="Preact: median 7.6ms · mean 7.4 ± 0.9 · range 5.3–8.4ms · 10 samples">
         <span class="bar-name">Preact</span>
-        <span class="bar-track"><span class="bar" data-fw="preact" style="width:80.6%"></span>
+        <span class="bar-track"><span class="bar" data-fw="preact" style="width:50.5%"></span>
         <span class="bar-value">7.6</span></span>
       </div>
       <div class="bar-row" data-tip="Vue: median 8.1ms · mean 8.1 ± 0.4 · range 7.6–9.0ms · 10 samples">
         <span class="bar-name">Vue</span>
-        <span class="bar-track"><span class="bar" data-fw="vue" style="width:86.0%"></span>
+        <span class="bar-track"><span class="bar" data-fw="vue" style="width:53.9%"></span>
         <span class="bar-value">8.1</span></span>
       </div>
       <div class="bar-row" data-tip="Svelte: median 7.2ms · mean 7.3 ± 0.8 · range 5.6–8.2ms · 10 samples">
         <span class="bar-name">Svelte</span>
-        <span class="bar-track"><span class="bar" data-fw="svelte" style="width:76.7%"></span>
+        <span class="bar-track"><span class="bar" data-fw="svelte" style="width:48.1%"></span>
         <span class="bar-value">7.2</span></span>
       </div>
       <div class="bar-row" data-tip="Vanilla JS: median 7.6ms · mean 7.4 ± 1.2 · range 5.0–9.6ms · 10 samples">
         <span class="bar-name">Vanilla JS</span>
-        <span class="bar-track"><span class="bar" data-fw="vanilla" style="width:80.5%"></span>
+        <span class="bar-track"><span class="bar" data-fw="vanilla" style="width:50.5%"></span>
         <span class="bar-value">7.6</span></span>
+      </div>
+      <div class="bar-row" data-tip="Compose HTML: median 12.9ms · mean 12.8 ± 1.9 · range 9.6–15.3ms · 5 samples">
+        <span class="bar-name">Compose HTML</span>
+        <span class="bar-track"><span class="bar" data-fw="compose-web" style="width:86.0%"></span>
+        <span class="bar-value">12.9</span></span>
       </div></div>
 
   </figure>
@@ -623,33 +674,38 @@ footer { margin-top: 48px; color: var(--muted); font-size: 12.5px; }
     <div class="bars" data-unit="ms">
       <div class="bar-row" data-tip="Kinetica: median 7.8ms · mean 7.7 ± 0.5 · range 6.7–8.4ms · 10 samples">
         <span class="bar-name">Kinetica</span>
-        <span class="bar-track"><span class="bar" data-fw="kinetica" style="width:86.0%"></span>
+        <span class="bar-track"><span class="bar" data-fw="kinetica" style="width:63.7%"></span>
         <span class="bar-value">7.8</span></span>
       </div>
       <div class="bar-row" data-tip="React: median 7.6ms · mean 7.3 ± 0.7 · range 6.3–8.0ms · 10 samples">
         <span class="bar-name">React</span>
-        <span class="bar-track"><span class="bar" data-fw="react" style="width:84.6%"></span>
+        <span class="bar-track"><span class="bar" data-fw="react" style="width:62.7%"></span>
         <span class="bar-value">7.6</span></span>
       </div>
       <div class="bar-row" data-tip="Preact: median 7.4ms · mean 7.6 ± 0.6 · range 6.6–8.4ms · 10 samples">
         <span class="bar-name">Preact</span>
-        <span class="bar-track"><span class="bar" data-fw="preact" style="width:82.3%"></span>
+        <span class="bar-track"><span class="bar" data-fw="preact" style="width:61.0%"></span>
         <span class="bar-value">7.4</span></span>
       </div>
       <div class="bar-row" data-tip="Vue: median 7.2ms · mean 7.2 ± 0.3 · range 6.9–7.5ms · 10 samples">
         <span class="bar-name">Vue</span>
-        <span class="bar-track"><span class="bar" data-fw="vue" style="width:79.2%"></span>
+        <span class="bar-track"><span class="bar" data-fw="vue" style="width:58.7%"></span>
         <span class="bar-value">7.2</span></span>
       </div>
       <div class="bar-row" data-tip="Svelte: median 7.4ms · mean 7.4 ± 0.6 · range 6.3–8.3ms · 10 samples">
         <span class="bar-name">Svelte</span>
-        <span class="bar-track"><span class="bar" data-fw="svelte" style="width:81.6%"></span>
+        <span class="bar-track"><span class="bar" data-fw="svelte" style="width:60.5%"></span>
         <span class="bar-value">7.4</span></span>
       </div>
       <div class="bar-row" data-tip="Vanilla JS: median 7.6ms · mean 7.4 ± 1.2 · range 4.6–8.6ms · 10 samples">
         <span class="bar-name">Vanilla JS</span>
-        <span class="bar-track"><span class="bar" data-fw="vanilla" style="width:84.2%"></span>
+        <span class="bar-track"><span class="bar" data-fw="vanilla" style="width:62.4%"></span>
         <span class="bar-value">7.6</span></span>
+      </div>
+      <div class="bar-row" data-tip="Compose HTML: median 10.5ms · mean 10.1 ± 0.7 · range 9.2–10.9ms · 5 samples">
+        <span class="bar-name">Compose HTML</span>
+        <span class="bar-track"><span class="bar" data-fw="compose-web" style="width:86.0%"></span>
+        <span class="bar-value">10.5</span></span>
       </div></div>
 
   </figure>
@@ -658,33 +714,38 @@ footer { margin-top: 48px; color: var(--muted); font-size: 12.5px; }
     <div class="bars" data-unit="ms">
       <div class="bar-row" data-tip="Kinetica: median 8.1ms · mean 8.0 ± 1.3 · range 5.4–10.5ms · 10 samples">
         <span class="bar-name">Kinetica</span>
-        <span class="bar-track"><span class="bar" data-fw="kinetica" style="width:31.1%"></span>
+        <span class="bar-track"><span class="bar" data-fw="kinetica" style="width:1.2%"></span>
         <span class="bar-value">8.1</span></span>
       </div>
       <div class="bar-row" data-tip="React: median 22.5ms · mean 24.6 ± 4.6 · range 19.9–33.3ms · 10 samples">
         <span class="bar-name">React</span>
-        <span class="bar-track"><span class="bar" data-fw="react" style="width:86.0%"></span>
+        <span class="bar-track"><span class="bar" data-fw="react" style="width:3.4%"></span>
         <span class="bar-value">22.5</span></span>
       </div>
       <div class="bar-row" data-tip="Preact: median 7.3ms · mean 7.2 ± 0.9 · range 5.9–8.5ms · 10 samples">
         <span class="bar-name">Preact</span>
-        <span class="bar-track"><span class="bar" data-fw="preact" style="width:28.0%"></span>
+        <span class="bar-track"><span class="bar" data-fw="preact" style="width:1.1%"></span>
         <span class="bar-value">7.3</span></span>
       </div>
       <div class="bar-row" data-tip="Vue: median 8.3ms · mean 8.3 ± 1.1 · range 6.6–11.0ms · 10 samples">
         <span class="bar-name">Vue</span>
-        <span class="bar-track"><span class="bar" data-fw="vue" style="width:31.6%"></span>
+        <span class="bar-track"><span class="bar" data-fw="vue" style="width:1.3%"></span>
         <span class="bar-value">8.3</span></span>
       </div>
       <div class="bar-row" data-tip="Svelte: median 7.8ms · mean 7.7 ± 0.5 · range 6.6–8.6ms · 10 samples">
         <span class="bar-name">Svelte</span>
-        <span class="bar-track"><span class="bar" data-fw="svelte" style="width:29.8%"></span>
+        <span class="bar-track"><span class="bar" data-fw="svelte" style="width:1.2%"></span>
         <span class="bar-value">7.8</span></span>
       </div>
       <div class="bar-row" data-tip="Vanilla JS: median 7.4ms · mean 7.2 ± 0.8 · range 6.0–8.2ms · 10 samples">
         <span class="bar-name">Vanilla JS</span>
-        <span class="bar-track"><span class="bar" data-fw="vanilla" style="width:28.3%"></span>
+        <span class="bar-track"><span class="bar" data-fw="vanilla" style="width:1.1%"></span>
         <span class="bar-value">7.4</span></span>
+      </div>
+      <div class="bar-row" data-tip="Compose HTML: median 561.8ms · mean 561.2 ± 3.2 · range 555.7–565.6ms · 5 samples">
+        <span class="bar-name">Compose HTML</span>
+        <span class="bar-track"><span class="bar" data-fw="compose-web" style="width:86.0%"></span>
+        <span class="bar-value">561.8</span></span>
       </div></div>
 
   </figure>
@@ -693,33 +754,38 @@ footer { margin-top: 48px; color: var(--muted); font-size: 12.5px; }
     <div class="bars" data-unit="ms">
       <div class="bar-row" data-tip="Kinetica: median 8.5ms · mean 8.5 ± 0.7 · range 7.4–9.4ms · 10 samples">
         <span class="bar-name">Kinetica</span>
-        <span class="bar-track"><span class="bar" data-fw="kinetica" style="width:86.0%"></span>
+        <span class="bar-track"><span class="bar" data-fw="kinetica" style="width:1.4%"></span>
         <span class="bar-value">8.5</span></span>
       </div>
       <div class="bar-row" data-tip="React: median 7.4ms · mean 7.3 ± 0.7 · range 5.9–8.7ms · 10 samples">
         <span class="bar-name">React</span>
-        <span class="bar-track"><span class="bar" data-fw="react" style="width:74.7%"></span>
+        <span class="bar-track"><span class="bar" data-fw="react" style="width:1.2%"></span>
         <span class="bar-value">7.4</span></span>
       </div>
       <div class="bar-row" data-tip="Preact: median 7.4ms · mean 7.3 ± 0.7 · range 6.3–8.7ms · 10 samples">
         <span class="bar-name">Preact</span>
-        <span class="bar-track"><span class="bar" data-fw="preact" style="width:74.2%"></span>
+        <span class="bar-track"><span class="bar" data-fw="preact" style="width:1.2%"></span>
         <span class="bar-value">7.4</span></span>
       </div>
       <div class="bar-row" data-tip="Vue: median 7.2ms · mean 7.2 ± 0.7 · range 5.9–8.2ms · 10 samples">
         <span class="bar-name">Vue</span>
-        <span class="bar-track"><span class="bar" data-fw="vue" style="width:72.1%"></span>
+        <span class="bar-track"><span class="bar" data-fw="vue" style="width:1.2%"></span>
         <span class="bar-value">7.2</span></span>
       </div>
       <div class="bar-row" data-tip="Svelte: median 7.2ms · mean 7.2 ± 0.5 · range 6.2–7.9ms · 10 samples">
         <span class="bar-name">Svelte</span>
-        <span class="bar-track"><span class="bar" data-fw="svelte" style="width:72.6%"></span>
+        <span class="bar-track"><span class="bar" data-fw="svelte" style="width:1.2%"></span>
         <span class="bar-value">7.2</span></span>
       </div>
       <div class="bar-row" data-tip="Vanilla JS: median 7.3ms · mean 7.3 ± 0.6 · range 6.2–8.4ms · 10 samples">
         <span class="bar-name">Vanilla JS</span>
-        <span class="bar-track"><span class="bar" data-fw="vanilla" style="width:73.9%"></span>
+        <span class="bar-track"><span class="bar" data-fw="vanilla" style="width:1.2%"></span>
         <span class="bar-value">7.3</span></span>
+      </div>
+      <div class="bar-row" data-tip="Compose HTML: median 522.0ms · mean 523.8 ± 5.7 · range 516.9–533.6ms · 5 samples">
+        <span class="bar-name">Compose HTML</span>
+        <span class="bar-track"><span class="bar" data-fw="compose-web" style="width:86.0%"></span>
+        <span class="bar-value">522.0</span></span>
       </div></div>
 
   </figure>
@@ -728,33 +794,38 @@ footer { margin-top: 48px; color: var(--muted); font-size: 12.5px; }
     <div class="bars" data-unit="ms">
       <div class="bar-row" data-tip="Kinetica: median 283.8ms · mean 292.7 ± 19.2 · range 278.5–343.2ms · 10 samples">
         <span class="bar-name">Kinetica</span>
-        <span class="bar-track"><span class="bar" data-fw="kinetica" style="width:77.2%"></span>
+        <span class="bar-track"><span class="bar" data-fw="kinetica" style="width:3.1%"></span>
         <span class="bar-value">283.8</span></span>
       </div>
       <div class="bar-row" data-tip="React: median 316.0ms · mean 348.0 ± 103.0 · range 295.2–655.8ms · 10 samples">
         <span class="bar-name">React</span>
-        <span class="bar-track"><span class="bar" data-fw="react" style="width:86.0%"></span>
+        <span class="bar-track"><span class="bar" data-fw="react" style="width:3.4%"></span>
         <span class="bar-value">316.0</span></span>
       </div>
       <div class="bar-row" data-tip="Preact: median 245.4ms · mean 248.7 ± 7.4 · range 237.6–263.2ms · 10 samples">
         <span class="bar-name">Preact</span>
-        <span class="bar-track"><span class="bar" data-fw="preact" style="width:66.8%"></span>
+        <span class="bar-track"><span class="bar" data-fw="preact" style="width:2.6%"></span>
         <span class="bar-value">245.4</span></span>
       </div>
       <div class="bar-row" data-tip="Vue: median 234.4ms · mean 238.2 ± 14.4 · range 221.7–275.1ms · 10 samples">
         <span class="bar-name">Vue</span>
-        <span class="bar-track"><span class="bar" data-fw="vue" style="width:63.8%"></span>
+        <span class="bar-track"><span class="bar" data-fw="vue" style="width:2.5%"></span>
         <span class="bar-value">234.4</span></span>
       </div>
       <div class="bar-row" data-tip="Svelte: median 203.9ms · mean 206.9 ± 15.0 · range 191.3–244.5ms · 10 samples">
         <span class="bar-name">Svelte</span>
-        <span class="bar-track"><span class="bar" data-fw="svelte" style="width:55.5%"></span>
+        <span class="bar-track"><span class="bar" data-fw="svelte" style="width:2.2%"></span>
         <span class="bar-value">203.9</span></span>
       </div>
       <div class="bar-row" data-tip="Vanilla JS: median 206.3ms · mean 205.9 ± 7.5 · range 192.6–216.5ms · 10 samples">
         <span class="bar-name">Vanilla JS</span>
-        <span class="bar-track"><span class="bar" data-fw="vanilla" style="width:56.2%"></span>
+        <span class="bar-track"><span class="bar" data-fw="vanilla" style="width:2.2%"></span>
         <span class="bar-value">206.3</span></span>
+      </div>
+      <div class="bar-row" data-tip="Compose HTML: median 7,995.6ms · mean 8,010.4 ± 78.5 · range 7,909.4–8,108.5ms · 5 samples">
+        <span class="bar-name">Compose HTML</span>
+        <span class="bar-track"><span class="bar" data-fw="compose-web" style="width:86.0%"></span>
+        <span class="bar-value">7,995.6</span></span>
       </div></div>
 
   </figure>
@@ -763,33 +834,38 @@ footer { margin-top: 48px; color: var(--muted); font-size: 12.5px; }
     <div class="bars" data-unit="ms">
       <div class="bar-row" data-tip="Kinetica: median 34.6ms · mean 36.4 ± 4.2 · range 31.7–42.9ms · 10 samples">
         <span class="bar-name">Kinetica</span>
-        <span class="bar-track"><span class="bar" data-fw="kinetica" style="width:75.8%"></span>
+        <span class="bar-track"><span class="bar" data-fw="kinetica" style="width:12.8%"></span>
         <span class="bar-value">34.6</span></span>
       </div>
       <div class="bar-row" data-tip="React: median 32.8ms · mean 32.0 ± 3.8 · range 25.7–36.4ms · 10 samples">
         <span class="bar-name">React</span>
-        <span class="bar-track"><span class="bar" data-fw="react" style="width:71.9%"></span>
+        <span class="bar-track"><span class="bar" data-fw="react" style="width:12.1%"></span>
         <span class="bar-value">32.8</span></span>
       </div>
       <div class="bar-row" data-tip="Preact: median 39.3ms · mean 38.9 ± 2.2 · range 35.1–41.3ms · 10 samples">
         <span class="bar-name">Preact</span>
-        <span class="bar-track"><span class="bar" data-fw="preact" style="width:86.0%"></span>
+        <span class="bar-track"><span class="bar" data-fw="preact" style="width:14.5%"></span>
         <span class="bar-value">39.3</span></span>
       </div>
       <div class="bar-row" data-tip="Vue: median 30.9ms · mean 29.9 ± 4.1 · range 23.6–36.1ms · 10 samples">
         <span class="bar-name">Vue</span>
-        <span class="bar-track"><span class="bar" data-fw="vue" style="width:67.6%"></span>
+        <span class="bar-track"><span class="bar" data-fw="vue" style="width:11.4%"></span>
         <span class="bar-value">30.9</span></span>
       </div>
       <div class="bar-row" data-tip="Svelte: median 32.3ms · mean 30.2 ± 5.7 · range 21.0–36.5ms · 10 samples">
         <span class="bar-name">Svelte</span>
-        <span class="bar-track"><span class="bar" data-fw="svelte" style="width:70.7%"></span>
+        <span class="bar-track"><span class="bar" data-fw="svelte" style="width:11.9%"></span>
         <span class="bar-value">32.3</span></span>
       </div>
       <div class="bar-row" data-tip="Vanilla JS: median 28.2ms · mean 29.3 ± 5.4 · range 21.0–35.8ms · 10 samples">
         <span class="bar-name">Vanilla JS</span>
-        <span class="bar-track"><span class="bar" data-fw="vanilla" style="width:61.8%"></span>
+        <span class="bar-track"><span class="bar" data-fw="vanilla" style="width:10.4%"></span>
         <span class="bar-value">28.2</span></span>
+      </div>
+      <div class="bar-row" data-tip="Compose HTML: median 233.1ms · mean 234.7 ± 3.2 · range 232.4–241.0ms · 5 samples">
+        <span class="bar-name">Compose HTML</span>
+        <span class="bar-track"><span class="bar" data-fw="compose-web" style="width:86.0%"></span>
+        <span class="bar-value">233.1</span></span>
       </div></div>
 
   </figure>
@@ -798,33 +874,38 @@ footer { margin-top: 48px; color: var(--muted); font-size: 12.5px; }
     <div class="bars" data-unit="ms">
       <div class="bar-row" data-tip="Kinetica: median 7.0ms · mean 6.8 ± 0.8 · range 5.5–7.9ms · 10 samples">
         <span class="bar-name">Kinetica</span>
-        <span class="bar-track"><span class="bar" data-fw="kinetica" style="width:83.6%"></span>
+        <span class="bar-track"><span class="bar" data-fw="kinetica" style="width:25.0%"></span>
         <span class="bar-value">7.0</span></span>
       </div>
       <div class="bar-row" data-tip="React: median 7.2ms · mean 7.2 ± 0.4 · range 6.7–8.0ms · 10 samples">
         <span class="bar-name">React</span>
-        <span class="bar-track"><span class="bar" data-fw="react" style="width:86.0%"></span>
+        <span class="bar-track"><span class="bar" data-fw="react" style="width:25.7%"></span>
         <span class="bar-value">7.2</span></span>
       </div>
       <div class="bar-row" data-tip="Preact: median 6.8ms · mean 6.9 ± 0.7 · range 5.9–8.1ms · 10 samples">
         <span class="bar-name">Preact</span>
-        <span class="bar-track"><span class="bar" data-fw="preact" style="width:81.1%"></span>
+        <span class="bar-track"><span class="bar" data-fw="preact" style="width:24.3%"></span>
         <span class="bar-value">6.8</span></span>
       </div>
       <div class="bar-row" data-tip="Vue: median 6.9ms · mean 7.0 ± 0.6 · range 6.2–8.1ms · 10 samples">
         <span class="bar-name">Vue</span>
-        <span class="bar-track"><span class="bar" data-fw="vue" style="width:81.9%"></span>
+        <span class="bar-track"><span class="bar" data-fw="vue" style="width:24.5%"></span>
         <span class="bar-value">6.9</span></span>
       </div>
       <div class="bar-row" data-tip="Svelte: median 6.9ms · mean 6.8 ± 0.5 · range 5.8–7.5ms · 10 samples">
         <span class="bar-name">Svelte</span>
-        <span class="bar-track"><span class="bar" data-fw="svelte" style="width:82.8%"></span>
+        <span class="bar-track"><span class="bar" data-fw="svelte" style="width:24.8%"></span>
         <span class="bar-value">6.9</span></span>
       </div>
       <div class="bar-row" data-tip="Vanilla JS: median 7.0ms · mean 6.7 ± 0.9 · range 5.3–7.6ms · 10 samples">
         <span class="bar-name">Vanilla JS</span>
-        <span class="bar-track"><span class="bar" data-fw="vanilla" style="width:83.7%"></span>
+        <span class="bar-track"><span class="bar" data-fw="vanilla" style="width:25.1%"></span>
         <span class="bar-value">7.0</span></span>
+      </div>
+      <div class="bar-row" data-tip="Compose HTML: median 24.1ms · mean 25.6 ± 4.2 · range 20.4–32.5ms · 5 samples">
+        <span class="bar-name">Compose HTML</span>
+        <span class="bar-track"><span class="bar" data-fw="compose-web" style="width:86.0%"></span>
+        <span class="bar-value">24.1</span></span>
       </div></div>
 
   </figure>
@@ -833,33 +914,38 @@ footer { margin-top: 48px; color: var(--muted); font-size: 12.5px; }
     <div class="bars" data-unit="ms">
       <div class="bar-row" data-tip="Kinetica: median 8.7ms · mean 9.1 ± 1.0 · range 8.1–11.1ms · 10 samples">
         <span class="bar-name">Kinetica</span>
-        <span class="bar-track"><span class="bar" data-fw="kinetica" style="width:49.1%"></span>
+        <span class="bar-track"><span class="bar" data-fw="kinetica" style="width:29.9%"></span>
         <span class="bar-value">8.7</span></span>
       </div>
       <div class="bar-row" data-tip="React: median 7.9ms · mean 7.9 ± 0.5 · range 7.1–8.6ms · 10 samples">
         <span class="bar-name">React</span>
-        <span class="bar-track"><span class="bar" data-fw="react" style="width:44.9%"></span>
+        <span class="bar-track"><span class="bar" data-fw="react" style="width:27.3%"></span>
         <span class="bar-value">7.9</span></span>
       </div>
       <div class="bar-row" data-tip="Preact: median 7.9ms · mean 7.9 ± 0.2 · range 7.6–8.3ms · 10 samples">
         <span class="bar-name">Preact</span>
-        <span class="bar-track"><span class="bar" data-fw="preact" style="width:44.6%"></span>
+        <span class="bar-track"><span class="bar" data-fw="preact" style="width:27.1%"></span>
         <span class="bar-value">7.9</span></span>
       </div>
       <div class="bar-row" data-tip="Vue: median 15.2ms · mean 15.1 ± 0.9 · range 13.8–16.6ms · 10 samples">
         <span class="bar-name">Vue</span>
-        <span class="bar-track"><span class="bar" data-fw="vue" style="width:86.0%"></span>
+        <span class="bar-track"><span class="bar" data-fw="vue" style="width:52.3%"></span>
         <span class="bar-value">15.2</span></span>
       </div>
       <div class="bar-row" data-tip="Svelte: median 7.7ms · mean 7.7 ± 0.6 · range 6.9–8.6ms · 10 samples">
         <span class="bar-name">Svelte</span>
-        <span class="bar-track"><span class="bar" data-fw="svelte" style="width:43.6%"></span>
+        <span class="bar-track"><span class="bar" data-fw="svelte" style="width:26.5%"></span>
         <span class="bar-value">7.7</span></span>
       </div>
       <div class="bar-row" data-tip="Vanilla JS: median 7.9ms · mean 8.0 ± 0.5 · range 7.5–8.8ms · 10 samples">
         <span class="bar-name">Vanilla JS</span>
-        <span class="bar-track"><span class="bar" data-fw="vanilla" style="width:44.6%"></span>
+        <span class="bar-track"><span class="bar" data-fw="vanilla" style="width:27.2%"></span>
         <span class="bar-value">7.9</span></span>
+      </div>
+      <div class="bar-row" data-tip="Compose HTML: median 25.0ms · mean 26.1 ± 3.8 · range 21.3–31.5ms · 5 samples">
+        <span class="bar-name">Compose HTML</span>
+        <span class="bar-track"><span class="bar" data-fw="compose-web" style="width:86.0%"></span>
+        <span class="bar-value">25.0</span></span>
       </div></div>
 
   </figure>
@@ -868,33 +954,38 @@ footer { margin-top: 48px; color: var(--muted); font-size: 12.5px; }
     <div class="bars" data-unit="ms">
       <div class="bar-row" data-tip="Kinetica: median 42.1ms · mean 42.6 ± 3.1 · range 37.6–48.7ms · 10 samples">
         <span class="bar-name">Kinetica</span>
-        <span class="bar-track"><span class="bar" data-fw="kinetica" style="width:66.9%"></span>
+        <span class="bar-track"><span class="bar" data-fw="kinetica" style="width:0.8%"></span>
         <span class="bar-value">42.1</span></span>
       </div>
       <div class="bar-row" data-tip="React: median 54.1ms · mean 53.9 ± 1.8 · range 50.8–57.5ms · 10 samples">
         <span class="bar-name">React</span>
-        <span class="bar-track"><span class="bar" data-fw="react" style="width:86.0%"></span>
+        <span class="bar-track"><span class="bar" data-fw="react" style="width:0.8%"></span>
         <span class="bar-value">54.1</span></span>
       </div>
       <div class="bar-row" data-tip="Preact: median 35.6ms · mean 36.6 ± 4.7 · range 31.8–47.8ms · 10 samples">
         <span class="bar-name">Preact</span>
-        <span class="bar-track"><span class="bar" data-fw="preact" style="width:56.6%"></span>
+        <span class="bar-track"><span class="bar" data-fw="preact" style="width:0.8%"></span>
         <span class="bar-value">35.6</span></span>
       </div>
       <div class="bar-row" data-tip="Vue: median 42.7ms · mean 42.1 ± 3.0 · range 35.8–45.7ms · 10 samples">
         <span class="bar-name">Vue</span>
-        <span class="bar-track"><span class="bar" data-fw="vue" style="width:67.9%"></span>
+        <span class="bar-track"><span class="bar" data-fw="vue" style="width:0.8%"></span>
         <span class="bar-value">42.7</span></span>
       </div>
       <div class="bar-row" data-tip="Svelte: median 30.0ms · mean 30.4 ± 2.0 · range 26.0–33.6ms · 10 samples">
         <span class="bar-name">Svelte</span>
-        <span class="bar-track"><span class="bar" data-fw="svelte" style="width:47.6%"></span>
+        <span class="bar-track"><span class="bar" data-fw="svelte" style="width:0.8%"></span>
         <span class="bar-value">30.0</span></span>
       </div>
       <div class="bar-row" data-tip="Vanilla JS: median 28.3ms · mean 29.0 ± 2.8 · range 26.3–34.1ms · 10 samples">
         <span class="bar-name">Vanilla JS</span>
-        <span class="bar-track"><span class="bar" data-fw="vanilla" style="width:45.0%"></span>
+        <span class="bar-track"><span class="bar" data-fw="vanilla" style="width:0.8%"></span>
         <span class="bar-value">28.3</span></span>
+      </div>
+      <div class="bar-row" data-tip="Compose HTML: median 9,554.4ms · mean 9,525.2 ± 59.2 · range 9,416.6–9,576.0ms · 5 samples">
+        <span class="bar-name">Compose HTML</span>
+        <span class="bar-track"><span class="bar" data-fw="compose-web" style="width:86.0%"></span>
+        <span class="bar-value">9,554.4</span></span>
       </div></div>
 
   </figure>
@@ -903,33 +994,38 @@ footer { margin-top: 48px; color: var(--muted); font-size: 12.5px; }
     <div class="bars" data-unit="ms">
       <div class="bar-row" data-tip="Kinetica: median 59.8ms · mean 60.2 ± 10.5 · range 47.6–75.7ms · 10 samples">
         <span class="bar-name">Kinetica</span>
-        <span class="bar-track"><span class="bar" data-fw="kinetica" style="width:86.0%"></span>
+        <span class="bar-track"><span class="bar" data-fw="kinetica" style="width:0.8%"></span>
         <span class="bar-value">59.8</span></span>
       </div>
       <div class="bar-row" data-tip="React: median 40.3ms · mean 40.9 ± 3.8 · range 36.1–50.5ms · 10 samples">
         <span class="bar-name">React</span>
-        <span class="bar-track"><span class="bar" data-fw="react" style="width:58.0%"></span>
+        <span class="bar-track"><span class="bar" data-fw="react" style="width:0.8%"></span>
         <span class="bar-value">40.3</span></span>
       </div>
       <div class="bar-row" data-tip="Preact: median 40.8ms · mean 43.1 ± 5.2 · range 38.6–53.0ms · 10 samples">
         <span class="bar-name">Preact</span>
-        <span class="bar-track"><span class="bar" data-fw="preact" style="width:58.7%"></span>
+        <span class="bar-track"><span class="bar" data-fw="preact" style="width:0.8%"></span>
         <span class="bar-value">40.8</span></span>
       </div>
       <div class="bar-row" data-tip="Vue: median 53.8ms · mean 55.2 ± 5.8 · range 49.1–71.8ms · 10 samples">
         <span class="bar-name">Vue</span>
-        <span class="bar-track"><span class="bar" data-fw="vue" style="width:77.5%"></span>
+        <span class="bar-track"><span class="bar" data-fw="vue" style="width:0.8%"></span>
         <span class="bar-value">53.8</span></span>
       </div>
       <div class="bar-row" data-tip="Svelte: median 38.8ms · mean 42.1 ± 8.0 · range 36.7–64.2ms · 10 samples">
         <span class="bar-name">Svelte</span>
-        <span class="bar-track"><span class="bar" data-fw="svelte" style="width:55.9%"></span>
+        <span class="bar-track"><span class="bar" data-fw="svelte" style="width:0.8%"></span>
         <span class="bar-value">38.8</span></span>
       </div>
       <div class="bar-row" data-tip="Vanilla JS: median 44.4ms · mean 44.9 ± 7.8 · range 36.2–57.0ms · 10 samples">
         <span class="bar-name">Vanilla JS</span>
-        <span class="bar-track"><span class="bar" data-fw="vanilla" style="width:63.9%"></span>
+        <span class="bar-track"><span class="bar" data-fw="vanilla" style="width:0.8%"></span>
         <span class="bar-value">44.4</span></span>
+      </div>
+      <div class="bar-row" data-tip="Compose HTML: median 49,552.8ms · mean 49,663.2 ± 355.8 · range 49,289.4–50,205.0ms · 5 samples">
+        <span class="bar-name">Compose HTML</span>
+        <span class="bar-track"><span class="bar" data-fw="compose-web" style="width:86.0%"></span>
+        <span class="bar-value">49,552.8</span></span>
       </div></div>
 
   </figure>
@@ -938,33 +1034,38 @@ footer { margin-top: 48px; color: var(--muted); font-size: 12.5px; }
     <div class="bars" data-unit="ms">
       <div class="bar-row" data-tip="Kinetica: median 43.3ms · mean 49.1 ± 14.2 · range 37.5–86.2ms · 10 samples">
         <span class="bar-name">Kinetica</span>
-        <span class="bar-track"><span class="bar" data-fw="kinetica" style="width:82.5%"></span>
+        <span class="bar-track"><span class="bar" data-fw="kinetica" style="width:28.6%"></span>
         <span class="bar-value">43.3</span></span>
       </div>
       <div class="bar-row" data-tip="React: median 34.4ms · mean 34.2 ± 1.9 · range 31.6–38.7ms · 10 samples">
         <span class="bar-name">React</span>
-        <span class="bar-track"><span class="bar" data-fw="react" style="width:65.6%"></span>
+        <span class="bar-track"><span class="bar" data-fw="react" style="width:22.8%"></span>
         <span class="bar-value">34.4</span></span>
       </div>
       <div class="bar-row" data-tip="Preact: median 36.6ms · mean 37.8 ± 3.3 · range 33.8–46.4ms · 10 samples">
         <span class="bar-name">Preact</span>
-        <span class="bar-track"><span class="bar" data-fw="preact" style="width:69.8%"></span>
+        <span class="bar-track"><span class="bar" data-fw="preact" style="width:24.2%"></span>
         <span class="bar-value">36.6</span></span>
       </div>
       <div class="bar-row" data-tip="Vue: median 45.1ms · mean 45.3 ± 2.5 · range 41.3–50.7ms · 10 samples">
         <span class="bar-name">Vue</span>
-        <span class="bar-track"><span class="bar" data-fw="vue" style="width:86.0%"></span>
+        <span class="bar-track"><span class="bar" data-fw="vue" style="width:29.8%"></span>
         <span class="bar-value">45.1</span></span>
       </div>
       <div class="bar-row" data-tip="Svelte: median 29.4ms · mean 30.6 ± 3.1 · range 27.0–37.8ms · 10 samples">
         <span class="bar-name">Svelte</span>
-        <span class="bar-track"><span class="bar" data-fw="svelte" style="width:56.1%"></span>
+        <span class="bar-track"><span class="bar" data-fw="svelte" style="width:19.5%"></span>
         <span class="bar-value">29.4</span></span>
       </div>
       <div class="bar-row" data-tip="Vanilla JS: median 32.1ms · mean 34.5 ± 4.8 · range 28.6–43.5ms · 10 samples">
         <span class="bar-name">Vanilla JS</span>
-        <span class="bar-track"><span class="bar" data-fw="vanilla" style="width:61.2%"></span>
+        <span class="bar-track"><span class="bar" data-fw="vanilla" style="width:21.2%"></span>
         <span class="bar-value">32.1</span></span>
+      </div>
+      <div class="bar-row" data-tip="Compose HTML: median 130.0ms · mean 120.8 ± 18.5 · range 98.2–143.3ms · 5 samples">
+        <span class="bar-name">Compose HTML</span>
+        <span class="bar-track"><span class="bar" data-fw="compose-web" style="width:86.0%"></span>
+        <span class="bar-value">130.0</span></span>
       </div></div>
 
   </figure></div>
@@ -980,15 +1081,79 @@ footer { margin-top: 48px; color: var(--muted); font-size: 12.5px; }
     <div class="table-scroll">
       <table class="results num-table">
         <thead>
-          <tr><th></th><th scope="col"><span class="swatch" data-fw="kinetica"></span>Kinetica</th><th scope="col"><span class="swatch" data-fw="react"></span>React</th><th scope="col"><span class="swatch" data-fw="preact"></span>Preact</th><th scope="col"><span class="swatch" data-fw="vue"></span>Vue</th><th scope="col"><span class="swatch" data-fw="svelte"></span>Svelte</th><th scope="col"><span class="swatch" data-fw="vanilla"></span>Vanilla JS</th></tr>
+          <tr><th></th><th scope="col"><span class="swatch" data-fw="kinetica"></span>Kinetica</th><th scope="col"><span class="swatch" data-fw="react"></span>React</th><th scope="col"><span class="swatch" data-fw="preact"></span>Preact</th><th scope="col"><span class="swatch" data-fw="vue"></span>Vue</th><th scope="col"><span class="swatch" data-fw="svelte"></span>Svelte</th><th scope="col"><span class="swatch" data-fw="vanilla"></span>Vanilla JS</th><th scope="col"><span class="swatch" data-fw="compose-web"></span>Compose HTML</th></tr>
         </thead>
-        <tbody><tr><th scope="row">create 10,000 rows</th><td class="num" title="Kinetica · create 10,000 rows: 151.0ms GC of 283.8ms total (max 206.6ms, ~323.2 GCs/op)">
+        <tbody><tr><th scope="row">create 1,000 rows</th><td class="num" title="Kinetica · create 1,000 rows: 0.0ms GC of 34.9ms total (max 0.0ms, ~0.0 GCs/op)">
+          0.0<span class="factor"> 0%</span></td><td class="num" title="React · create 1,000 rows: 0.0ms GC of 33.5ms total (max 0.0ms, ~0.0 GCs/op)">
+          0.0<span class="factor"> 0%</span></td><td class="num" title="Preact · create 1,000 rows: 0.0ms GC of 32.6ms total (max 9.4ms, ~8.6 GCs/op)">
+          0.0<span class="factor"> 0%</span></td><td class="num" title="Vue · create 1,000 rows: 0.0ms GC of 36.1ms total (max 13.9ms, ~7.4 GCs/op)">
+          0.0<span class="factor"> 0%</span></td><td class="num" title="Svelte · create 1,000 rows: 0.0ms GC of 26.3ms total (max 0.0ms, ~0.0 GCs/op)">
+          0.0<span class="factor"> 0%</span></td><td class="num" title="Vanilla JS · create 1,000 rows: 0.0ms GC of 25.5ms total (max 0.0ms, ~0.0 GCs/op)">
+          0.0<span class="factor"> 0%</span></td><td class="num" title="Compose HTML · create 1,000 rows: 59.3ms GC of 237.7ms total (max 64.0ms, ~251.0 GCs/op)">
+          59.3<span class="factor"> 25%</span></td></tr><tr><th scope="row">replace all 1,000 rows</th><td class="num" title="Kinetica · replace all 1,000 rows: 0.0ms GC of 33.6ms total (max 0.0ms, ~0.0 GCs/op)">
+          0.0<span class="factor"> 0%</span></td><td class="num" title="React · replace all 1,000 rows: 0.0ms GC of 37.4ms total (max 0.0ms, ~0.0 GCs/op)">
+          0.0<span class="factor"> 0%</span></td><td class="num" title="Preact · replace all 1,000 rows: 0.0ms GC of 33.2ms total (max 0.0ms, ~0.0 GCs/op)">
+          0.0<span class="factor"> 0%</span></td><td class="num" title="Vue · replace all 1,000 rows: 0.0ms GC of 34.2ms total (max 0.0ms, ~0.0 GCs/op)">
+          0.0<span class="factor"> 0%</span></td><td class="num" title="Svelte · replace all 1,000 rows: 0.0ms GC of 31.4ms total (max 0.0ms, ~0.0 GCs/op)">
+          0.0<span class="factor"> 0%</span></td><td class="num" title="Vanilla JS · replace all 1,000 rows: 0.0ms GC of 32.6ms total (max 0.0ms, ~0.0 GCs/op)">
+          0.0<span class="factor"> 0%</span></td><td class="num" title="Compose HTML · replace all 1,000 rows: 76.4ms GC of 362.0ms total (max 119.5ms, ~791.8 GCs/op)">
+          76.4<span class="factor"> 21%</span></td></tr><tr><th scope="row">swap two rows</th><td class="num" title="Kinetica · swap two rows: 0.0ms GC of 8.1ms total (max 0.0ms, ~0.0 GCs/op)">
+          0.0<span class="factor"> 0%</span></td><td class="num" title="React · swap two rows: 0.0ms GC of 22.5ms total (max 0.0ms, ~0.0 GCs/op)">
+          0.0<span class="factor"> 0%</span></td><td class="num" title="Preact · swap two rows: 0.0ms GC of 7.3ms total (max 0.0ms, ~0.0 GCs/op)">
+          0.0<span class="factor"> 0%</span></td><td class="num" title="Vue · swap two rows: 0.0ms GC of 8.3ms total (max 6.9ms, ~3.4 GCs/op)">
+          0.0<span class="factor"> 0%</span></td><td class="num" title="Svelte · swap two rows: 0.0ms GC of 7.8ms total (max 0.0ms, ~0.0 GCs/op)">
+          0.0<span class="factor"> 0%</span></td><td class="num" title="Vanilla JS · swap two rows: 0.0ms GC of 7.4ms total (max 0.0ms, ~0.0 GCs/op)">
+          0.0<span class="factor"> 0%</span></td><td class="num" title="Compose HTML · swap two rows: 7.2ms GC of 561.8ms total (max 8.5ms, ~247.4 GCs/op)">
+          7.2<span class="factor"> 1%</span></td></tr><tr><th scope="row">remove one row</th><td class="num" title="Kinetica · remove one row: 0.0ms GC of 8.5ms total (max 0.0ms, ~0.0 GCs/op)">
+          0.0<span class="factor"> 0%</span></td><td class="num" title="React · remove one row: 0.0ms GC of 7.4ms total (max 0.0ms, ~0.0 GCs/op)">
+          0.0<span class="factor"> 0%</span></td><td class="num" title="Preact · remove one row: 0.0ms GC of 7.4ms total (max 0.0ms, ~0.0 GCs/op)">
+          0.0<span class="factor"> 0%</span></td><td class="num" title="Vue · remove one row: 0.0ms GC of 7.2ms total (max 0.0ms, ~0.0 GCs/op)">
+          0.0<span class="factor"> 0%</span></td><td class="num" title="Svelte · remove one row: 0.0ms GC of 7.2ms total (max 0.0ms, ~0.0 GCs/op)">
+          0.0<span class="factor"> 0%</span></td><td class="num" title="Vanilla JS · remove one row: 0.0ms GC of 7.3ms total (max 0.0ms, ~0.0 GCs/op)">
+          0.0<span class="factor"> 0%</span></td><td class="num" title="Compose HTML · remove one row: 7.7ms GC of 522.0ms total (max 11.3ms, ~137.8 GCs/op)">
+          7.7<span class="factor"> 1%</span></td></tr><tr><th scope="row">create 10,000 rows</th><td class="num" title="Kinetica · create 10,000 rows: 151.0ms GC of 283.8ms total (max 206.6ms, ~323.2 GCs/op)">
           151.0<span class="factor"> 53%</span></td><td class="num" title="React · create 10,000 rows: 0.0ms GC of 316.0ms total (max 80.8ms, ~73.0 GCs/op)">
           0.0<span class="factor"> 0%</span></td><td class="num" title="Preact · create 10,000 rows: 51.2ms GC of 245.4ms total (max 60.7ms, ~34.5 GCs/op)">
           51.2<span class="factor"> 21%</span></td><td class="num" title="Vue · create 10,000 rows: 25.2ms GC of 234.4ms total (max 104.1ms, ~450.4 GCs/op)">
           25.2<span class="factor"> 11%</span></td><td class="num" title="Svelte · create 10,000 rows: 64.5ms GC of 203.9ms total (max 89.1ms, ~385.5 GCs/op)">
           64.5<span class="factor"> 32%</span></td><td class="num" title="Vanilla JS · create 10,000 rows: 6.2ms GC of 206.3ms total (max 29.3ms, ~132.8 GCs/op)">
-          6.2<span class="factor"> 3%</span></td></tr></tbody>
+          6.2<span class="factor"> 3%</span></td><td class="num" title="Compose HTML · create 10,000 rows: 1,346.1ms GC of 7,995.6ms total (max 1,415.9ms, ~9,581.4 GCs/op)">
+          1,346.1<span class="factor"> 17%</span></td></tr><tr><th scope="row">append 1,000 rows to 1,000</th><td class="num" title="Kinetica · append 1,000 rows to 1,000: 0.0ms GC of 34.6ms total (max 0.0ms, ~0.0 GCs/op)">
+          0.0<span class="factor"> 0%</span></td><td class="num" title="React · append 1,000 rows to 1,000: 0.0ms GC of 32.8ms total (max 0.0ms, ~0.0 GCs/op)">
+          0.0<span class="factor"> 0%</span></td><td class="num" title="Preact · append 1,000 rows to 1,000: 0.0ms GC of 39.3ms total (max 0.0ms, ~0.0 GCs/op)">
+          0.0<span class="factor"> 0%</span></td><td class="num" title="Vue · append 1,000 rows to 1,000: 0.0ms GC of 30.9ms total (max 0.0ms, ~0.0 GCs/op)">
+          0.0<span class="factor"> 0%</span></td><td class="num" title="Svelte · append 1,000 rows to 1,000: 0.0ms GC of 32.3ms total (max 0.0ms, ~0.0 GCs/op)">
+          0.0<span class="factor"> 0%</span></td><td class="num" title="Vanilla JS · append 1,000 rows to 1,000: 0.0ms GC of 28.2ms total (max 0.0ms, ~0.0 GCs/op)">
+          0.0<span class="factor"> 0%</span></td><td class="num" title="Compose HTML · append 1,000 rows to 1,000: 55.8ms GC of 233.1ms total (max 65.4ms, ~229.6 GCs/op)">
+          55.8<span class="factor"> 24%</span></td></tr><tr><th scope="row">select row (10k table)</th><td class="num" title="Kinetica · select row (10k table): 0.0ms GC of 8.7ms total (max 0.0ms, ~0.0 GCs/op)">
+          0.0<span class="factor"> 0%</span></td><td class="num" title="React · select row (10k table): 0.0ms GC of 7.9ms total (max 0.0ms, ~0.0 GCs/op)">
+          0.0<span class="factor"> 0%</span></td><td class="num" title="Preact · select row (10k table): 0.0ms GC of 7.9ms total (max 0.0ms, ~0.0 GCs/op)">
+          0.0<span class="factor"> 0%</span></td><td class="num" title="Vue · select row (10k table): 0.0ms GC of 15.2ms total (max 0.0ms, ~0.0 GCs/op)">
+          0.0<span class="factor"> 0%</span></td><td class="num" title="Svelte · select row (10k table): 0.0ms GC of 7.7ms total (max 0.0ms, ~0.0 GCs/op)">
+          0.0<span class="factor"> 0%</span></td><td class="num" title="Vanilla JS · select row (10k table): 0.0ms GC of 7.9ms total (max 0.0ms, ~0.0 GCs/op)">
+          0.0<span class="factor"> 0%</span></td><td class="num" title="Compose HTML · select row (10k table): 18.5ms GC of 25.0ms total (max 27.4ms, ~30.8 GCs/op)">
+          18.5<span class="factor"> 74%</span></td></tr><tr><th scope="row">swap two rows (10k table)</th><td class="num" title="Kinetica · swap two rows (10k table): 0.0ms GC of 42.1ms total (max 0.0ms, ~0.0 GCs/op)">
+          0.0<span class="factor"> 0%</span></td><td class="num" title="React · swap two rows (10k table): 0.0ms GC of 54.1ms total (max 0.0ms, ~0.0 GCs/op)">
+          0.0<span class="factor"> 0%</span></td><td class="num" title="Preact · swap two rows (10k table): 0.0ms GC of 35.6ms total (max 0.0ms, ~0.0 GCs/op)">
+          0.0<span class="factor"> 0%</span></td><td class="num" title="Vue · swap two rows (10k table): 0.0ms GC of 42.7ms total (max 0.0ms, ~0.0 GCs/op)">
+          0.0<span class="factor"> 0%</span></td><td class="num" title="Svelte · swap two rows (10k table): 0.0ms GC of 30.0ms total (max 0.0ms, ~0.0 GCs/op)">
+          0.0<span class="factor"> 0%</span></td><td class="num" title="Vanilla JS · swap two rows (10k table): 0.0ms GC of 28.3ms total (max 0.0ms, ~0.0 GCs/op)">
+          0.0<span class="factor"> 0%</span></td><td class="num" title="Compose HTML · swap two rows (10k table): 83.5ms GC of 9,554.4ms total (max 156.9ms, ~2,290.0 GCs/op)">
+          83.5<span class="factor"> 1%</span></td></tr><tr><th scope="row">remove one row (10k table)</th><td class="num" title="Kinetica · remove one row (10k table): 0.0ms GC of 59.8ms total (max 0.0ms, ~0.0 GCs/op)">
+          0.0<span class="factor"> 0%</span></td><td class="num" title="React · remove one row (10k table): 0.0ms GC of 40.3ms total (max 0.0ms, ~0.0 GCs/op)">
+          0.0<span class="factor"> 0%</span></td><td class="num" title="Preact · remove one row (10k table): 0.0ms GC of 40.8ms total (max 0.0ms, ~0.0 GCs/op)">
+          0.0<span class="factor"> 0%</span></td><td class="num" title="Vue · remove one row (10k table): 0.0ms GC of 53.8ms total (max 0.0ms, ~0.0 GCs/op)">
+          0.0<span class="factor"> 0%</span></td><td class="num" title="Svelte · remove one row (10k table): 0.0ms GC of 38.8ms total (max 0.0ms, ~0.0 GCs/op)">
+          0.0<span class="factor"> 0%</span></td><td class="num" title="Vanilla JS · remove one row (10k table): 0.0ms GC of 44.4ms total (max 0.0ms, ~0.0 GCs/op)">
+          0.0<span class="factor"> 0%</span></td><td class="num" title="Compose HTML · remove one row (10k table): 384.3ms GC of 49,552.8ms total (max 429.8ms, ~6,763.0 GCs/op)">
+          384.3<span class="factor"> 1%</span></td></tr><tr><th scope="row">partial update (every 10th of 10k)</th><td class="num" title="Kinetica · partial update (every 10th of 10k): 0.0ms GC of 43.3ms total (max 0.0ms, ~0.0 GCs/op)">
+          0.0<span class="factor"> 0%</span></td><td class="num" title="React · partial update (every 10th of 10k): 0.0ms GC of 34.4ms total (max 0.0ms, ~0.0 GCs/op)">
+          0.0<span class="factor"> 0%</span></td><td class="num" title="Preact · partial update (every 10th of 10k): 0.0ms GC of 36.6ms total (max 0.0ms, ~0.0 GCs/op)">
+          0.0<span class="factor"> 0%</span></td><td class="num" title="Vue · partial update (every 10th of 10k): 0.0ms GC of 45.1ms total (max 0.0ms, ~0.0 GCs/op)">
+          0.0<span class="factor"> 0%</span></td><td class="num" title="Svelte · partial update (every 10th of 10k): 0.0ms GC of 29.4ms total (max 0.0ms, ~0.0 GCs/op)">
+          0.0<span class="factor"> 0%</span></td><td class="num" title="Vanilla JS · partial update (every 10th of 10k): 0.0ms GC of 32.1ms total (max 0.0ms, ~0.0 GCs/op)">
+          0.0<span class="factor"> 0%</span></td><td class="num" title="Compose HTML · partial update (every 10th of 10k): 29.9ms GC of 130.0ms total (max 45.6ms, ~39.4 GCs/op)">
+          29.9<span class="factor"> 23%</span></td></tr></tbody>
       </table>
     </div>
   </section>
@@ -1085,6 +1250,11 @@ footer { margin-top: 48px; color: var(--muted); font-size: 12.5px; }
         <span class="bar-name">Vanilla JS</span>
         <span class="bar-track"><span class="bar" data-fw="vanilla" style="width:86.0%"></span>
         <span class="bar-value">9.3 ms</span></span>
+      </div>
+      <div class="bar-row" data-tip="Compose HTML: 120 fps over 665 frames · median 8.3ms · p95 9.3ms · 0.0% frames >25ms">
+        <span class="bar-name">Compose HTML</span>
+        <span class="bar-track"><span class="bar" data-fw="compose-web" style="width:86.0%"></span>
+        <span class="bar-value">9.3 ms</span></span>
       </div></div>
     <p class="chart-note">Frame deltas from a requestAnimationFrame collector injected by the driver; the first 500ms are discarded as ramp-up. A steady 120Hz display budget is 8.3ms; >25ms means visibly dropped frames.</p>
   </figure></div>
@@ -1102,59 +1272,67 @@ footer { margin-top: 48px; color: var(--muted); font-size: 12.5px; }
     <div class="table-scroll">
       <table class="results">
         <thead>
-          <tr><th></th><th scope="col"><span class="swatch" data-fw="kinetica"></span>Kinetica</th><th scope="col"><span class="swatch" data-fw="react"></span>React</th><th scope="col"><span class="swatch" data-fw="preact"></span>Preact</th><th scope="col"><span class="swatch" data-fw="vue"></span>Vue</th><th scope="col"><span class="swatch" data-fw="svelte"></span>Svelte</th><th scope="col"><span class="swatch" data-fw="vanilla"></span>Vanilla JS</th></tr>
+          <tr><th></th><th scope="col"><span class="swatch" data-fw="kinetica"></span>Kinetica</th><th scope="col"><span class="swatch" data-fw="react"></span>React</th><th scope="col"><span class="swatch" data-fw="preact"></span>Preact</th><th scope="col"><span class="swatch" data-fw="vue"></span>Vue</th><th scope="col"><span class="swatch" data-fw="svelte"></span>Svelte</th><th scope="col"><span class="swatch" data-fw="vanilla"></span>Vanilla JS</th><th scope="col"><span class="swatch" data-fw="compose-web"></span>Compose HTML</th></tr>
         </thead>
         <tbody>
           <tr><th scope="row">create tree (1555 nodes)</th><td class="cell" style="--cell:#cde2fb" data-dark="false"
           title="Kinetica · create tree (1555 nodes): median 12.6ms (mean 13.5 ± 2.0, min 11.5, max 17.7, n=10)">
-          <span class="ms">12.6</span><span class="factor">1.0×</span></td><td class="cell" style="--cell:#5598e7" data-dark="false"
+          <span class="ms">12.6</span><span class="factor">1.0×</span></td><td class="cell" style="--cell:#9ec5f4" data-dark="false"
           title="React · create tree (1555 nodes): median 15.5ms (mean 15.0 ± 2.5, min 10.9, max 18.7, n=10)">
-          <span class="ms">15.5</span><span class="factor">1.2×</span></td><td class="cell" style="--cell:#5598e7" data-dark="false"
+          <span class="ms">15.5</span><span class="factor">1.2×</span></td><td class="cell" style="--cell:#9ec5f4" data-dark="false"
           title="Preact · create tree (1555 nodes): median 15.5ms (mean 15.7 ± 2.6, min 11.5, max 19.0, n=10)">
-          <span class="ms">15.5</span><span class="factor">1.2×</span></td><td class="cell" style="--cell:#184f95" data-dark="true"
+          <span class="ms">15.5</span><span class="factor">1.2×</span></td><td class="cell" style="--cell:#6da7ec" data-dark="false"
           title="Vue · create tree (1555 nodes): median 19.0ms (mean 19.1 ± 2.9, min 13.9, max 24.7, n=10)">
-          <span class="ms">19.0</span><span class="factor">1.5×</span></td><td class="cell" style="--cell:#0d366b" data-dark="true"
+          <span class="ms">19.0</span><span class="factor">1.5×</span></td><td class="cell" style="--cell:#6da7ec" data-dark="false"
           title="Svelte · create tree (1555 nodes): median 20.2ms (mean 19.1 ± 3.2, min 12.7, max 23.0, n=10)">
-          <span class="ms">20.2</span><span class="factor">1.6×</span></td><td class="cell" style="--cell:#6da7ec" data-dark="false"
+          <span class="ms">20.2</span><span class="factor">1.6×</span></td><td class="cell" style="--cell:#b7d3f6" data-dark="false"
           title="Vanilla JS · create tree (1555 nodes): median 14.7ms (mean 14.1 ± 2.2, min 8.4, max 16.7, n=10)">
-          <span class="ms">14.7</span><span class="factor">1.2×</span></td></tr><tr><th scope="row">update every 10th leaf</th><td class="cell" style="--cell:#cde2fb" data-dark="false"
+          <span class="ms">14.7</span><span class="factor">1.2×</span></td><td class="cell" style="--cell:#0d366b" data-dark="true"
+          title="Compose HTML · create tree (1555 nodes): median 50.3ms (mean 51.0 ± 4.3, min 46.1, max 57.7, n=5, gc 23.9ms)">
+          <span class="ms">50.3</span><span class="factor">4.0×</span></td></tr><tr><th scope="row">update every 10th leaf</th><td class="cell" style="--cell:#cde2fb" data-dark="false"
           title="Kinetica · update every 10th leaf: median 6.2ms (mean 5.9 ± 0.9, min 4.5, max 7.4, n=10)">
-          <span class="ms">6.2</span><span class="factor">1.0×</span></td><td class="cell" style="--cell:#86b6ef" data-dark="false"
+          <span class="ms">6.2</span><span class="factor">1.0×</span></td><td class="cell" style="--cell:#b7d3f6" data-dark="false"
           title="React · update every 10th leaf: median 6.9ms (mean 6.7 ± 0.8, min 5.5, max 8.0, n=10)">
-          <span class="ms">6.9</span><span class="factor">1.1×</span></td><td class="cell" style="--cell:#9ec5f4" data-dark="false"
+          <span class="ms">6.9</span><span class="factor">1.1×</span></td><td class="cell" style="--cell:#b7d3f6" data-dark="false"
           title="Preact · update every 10th leaf: median 6.6ms (mean 6.5 ± 1.0, min 4.2, max 7.4, n=10)">
-          <span class="ms">6.6</span><span class="factor">1.1×</span></td><td class="cell" style="--cell:#6da7ec" data-dark="false"
+          <span class="ms">6.6</span><span class="factor">1.1×</span></td><td class="cell" style="--cell:#b7d3f6" data-dark="false"
           title="Vue · update every 10th leaf: median 7.2ms (mean 7.3 ± 1.3, min 4.9, max 10.0, n=10)">
-          <span class="ms">7.2</span><span class="factor">1.2×</span></td><td class="cell" style="--cell:#86b6ef" data-dark="false"
+          <span class="ms">7.2</span><span class="factor">1.2×</span></td><td class="cell" style="--cell:#b7d3f6" data-dark="false"
           title="Svelte · update every 10th leaf: median 7.0ms (mean 7.1 ± 0.8, min 5.8, max 8.6, n=10)">
-          <span class="ms">7.0</span><span class="factor">1.1×</span></td><td class="cell" style="--cell:#9ec5f4" data-dark="false"
+          <span class="ms">7.0</span><span class="factor">1.1×</span></td><td class="cell" style="--cell:#b7d3f6" data-dark="false"
           title="Vanilla JS · update every 10th leaf: median 6.7ms (mean 6.5 ± 1.4, min 3.0, max 8.0, n=10)">
-          <span class="ms">6.7</span><span class="factor">1.1×</span></td></tr><tr><th scope="row">reverse top-level subtrees</th><td class="cell" style="--cell:#cde2fb" data-dark="false"
+          <span class="ms">6.7</span><span class="factor">1.1×</span></td><td class="cell" style="--cell:#3987e5" data-dark="true"
+          title="Compose HTML · update every 10th leaf: median 12.7ms (mean 12.9 ± 0.5, min 12.3, max 13.8, n=5)">
+          <span class="ms">12.7</span><span class="factor">2.1×</span></td></tr><tr><th scope="row">reverse top-level subtrees</th><td class="cell" style="--cell:#cde2fb" data-dark="false"
           title="Kinetica · reverse top-level subtrees: median 7.2ms (mean 7.1 ± 0.7, min 6.0, max 8.4, n=10, gc 0.7ms)">
-          <span class="ms">7.2</span><span class="factor">1.0×</span></td><td class="cell" style="--cell:#5598e7" data-dark="false"
+          <span class="ms">7.2</span><span class="factor">1.0×</span></td><td class="cell" style="--cell:#9ec5f4" data-dark="false"
           title="React · reverse top-level subtrees: median 8.8ms (mean 9.4 ± 1.7, min 7.2, max 12.4, n=10)">
-          <span class="ms">8.8</span><span class="factor">1.2×</span></td><td class="cell" style="--cell:#b7d3f6" data-dark="false"
+          <span class="ms">8.8</span><span class="factor">1.2×</span></td><td class="cell" style="--cell:#cde2fb" data-dark="false"
           title="Preact · reverse top-level subtrees: median 7.4ms (mean 7.5 ± 1.1, min 6.0, max 9.8, n=10)">
-          <span class="ms">7.4</span><span class="factor">1.0×</span></td><td class="cell" style="--cell:#5598e7" data-dark="false"
+          <span class="ms">7.4</span><span class="factor">1.0×</span></td><td class="cell" style="--cell:#9ec5f4" data-dark="false"
           title="Vue · reverse top-level subtrees: median 8.6ms (mean 8.7 ± 1.3, min 6.8, max 11.1, n=10)">
-          <span class="ms">8.6</span><span class="factor">1.2×</span></td><td class="cell" style="--cell:#3987e5" data-dark="true"
+          <span class="ms">8.6</span><span class="factor">1.2×</span></td><td class="cell" style="--cell:#9ec5f4" data-dark="false"
           title="Svelte · reverse top-level subtrees: median 8.9ms (mean 9.0 ± 1.1, min 7.4, max 10.9, n=10)">
-          <span class="ms">8.9</span><span class="factor">1.2×</span></td><td class="cell" style="--cell:#5598e7" data-dark="false"
+          <span class="ms">8.9</span><span class="factor">1.2×</span></td><td class="cell" style="--cell:#9ec5f4" data-dark="false"
           title="Vanilla JS · reverse top-level subtrees: median 8.8ms (mean 9.2 ± 1.3, min 7.4, max 11.1, n=10)">
-          <span class="ms">8.8</span><span class="factor">1.2×</span></td></tr><tr><th scope="row">no-op re-render (data unchanged)</th><td class="cell" style="--cell:#cde2fb" data-dark="false"
+          <span class="ms">8.8</span><span class="factor">1.2×</span></td><td class="cell" style="--cell:#2a78d6" data-dark="true"
+          title="Compose HTML · reverse top-level subtrees: median 16.1ms (mean 15.9 ± 0.6, min 14.8, max 16.5, n=5)">
+          <span class="ms">16.1</span><span class="factor">2.3×</span></td></tr><tr><th scope="row">no-op re-render (data unchanged)</th><td class="cell" style="--cell:#cde2fb" data-dark="false"
           title="Kinetica · no-op re-render (data unchanged): median 5.6ms (mean 5.5 ± 0.9, min 3.7, max 6.7, n=10)">
-          <span class="ms">5.6</span><span class="factor">1.0×</span></td><td class="cell" style="--cell:#5598e7" data-dark="false"
+          <span class="ms">5.6</span><span class="factor">1.0×</span></td><td class="cell" style="--cell:#9ec5f4" data-dark="false"
           title="React · no-op re-render (data unchanged): median 6.8ms (mean 6.3 ± 0.9, min 4.4, max 7.1, n=10)">
-          <span class="ms">6.8</span><span class="factor">1.2×</span></td><td class="cell" style="--cell:#6da7ec" data-dark="false"
+          <span class="ms">6.8</span><span class="factor">1.2×</span></td><td class="cell" style="--cell:#b7d3f6" data-dark="false"
           title="Preact · no-op re-render (data unchanged): median 6.5ms (mean 6.9 ± 0.8, min 5.6, max 8.0, n=10)">
-          <span class="ms">6.5</span><span class="factor">1.2×</span></td><td class="cell" style="--cell:#5598e7" data-dark="false"
+          <span class="ms">6.5</span><span class="factor">1.2×</span></td><td class="cell" style="--cell:#9ec5f4" data-dark="false"
           title="Vue · no-op re-render (data unchanged): median 6.7ms (mean 6.5 ± 1.1, min 4.6, max 8.0, n=10)">
-          <span class="ms">6.7</span><span class="factor">1.2×</span></td><td class="cell" style="--cell:#86b6ef" data-dark="false"
+          <span class="ms">6.7</span><span class="factor">1.2×</span></td><td class="cell" style="--cell:#b7d3f6" data-dark="false"
           title="Svelte · no-op re-render (data unchanged): median 6.3ms (mean 6.0 ± 1.2, min 3.2, max 7.3, n=10)">
-          <span class="ms">6.3</span><span class="factor">1.1×</span></td><td class="cell" style="--cell:#6da7ec" data-dark="false"
+          <span class="ms">6.3</span><span class="factor">1.1×</span></td><td class="cell" style="--cell:#b7d3f6" data-dark="false"
           title="Vanilla JS · no-op re-render (data unchanged): median 6.4ms (mean 6.4 ± 0.8, min 5.1, max 7.8, n=10)">
-          <span class="ms">6.4</span><span class="factor">1.2×</span></td></tr>
-          <tr class="geo-row"><th scope="row">geometric mean of factors</th><td class="cell geo" style="--cell:#cde2fb" data-dark="false"><span class="ms">1.00×</span></td><td class="cell geo" style="--cell:#5598e7" data-dark="false"><span class="ms">1.20×</span></td><td class="cell geo" style="--cell:#86b6ef" data-dark="false"><span class="ms">1.12×</span></td><td class="cell geo" style="--cell:#3987e5" data-dark="true"><span class="ms">1.26×</span></td><td class="cell geo" style="--cell:#3987e5" data-dark="true"><span class="ms">1.26×</span></td><td class="cell geo" style="--cell:#6da7ec" data-dark="false"><span class="ms">1.16×</span></td></tr>
+          <span class="ms">6.4</span><span class="factor">1.2×</span></td><td class="cell" style="--cell:#86b6ef" data-dark="false"
+          title="Compose HTML · no-op re-render (data unchanged): median 7.9ms (mean 7.6 ± 1.2, min 5.3, max 8.7, n=5)">
+          <span class="ms">7.9</span><span class="factor">1.4×</span></td></tr>
+          <tr class="geo-row"><th scope="row">geometric mean of factors</th><td class="cell geo" style="--cell:#cde2fb" data-dark="false"><span class="ms">1.00×</span></td><td class="cell geo" style="--cell:#9ec5f4" data-dark="false"><span class="ms">1.20×</span></td><td class="cell geo" style="--cell:#b7d3f6" data-dark="false"><span class="ms">1.12×</span></td><td class="cell geo" style="--cell:#9ec5f4" data-dark="false"><span class="ms">1.26×</span></td><td class="cell geo" style="--cell:#9ec5f4" data-dark="false"><span class="ms">1.26×</span></td><td class="cell geo" style="--cell:#b7d3f6" data-dark="false"><span class="ms">1.16×</span></td><td class="cell geo" style="--cell:#2a78d6" data-dark="true"><span class="ms">2.26×</span></td></tr>
         </tbody>
       </table>
     </div>
@@ -1170,33 +1348,38 @@ footer { margin-top: 48px; color: var(--muted); font-size: 12.5px; }
     <div class="bars" data-unit="KB">
       <div class="bar-row" data-tip="Kinetica: 83 KB gzipped · 263 KB raw · 1 file(s)">
         <span class="bar-name">Kinetica</span>
-        <span class="bar-track"><span class="bar" data-fw="kinetica" style="width:86.0%"></span>
+        <span class="bar-track"><span class="bar" data-fw="kinetica" style="width:41.6%"></span>
         <span class="bar-value">83 KB</span></span>
       </div>
       <div class="bar-row" data-tip="React: 60 KB gzipped · 193 KB raw · 1 file(s)">
         <span class="bar-name">React</span>
-        <span class="bar-track"><span class="bar" data-fw="react" style="width:62.5%"></span>
+        <span class="bar-track"><span class="bar" data-fw="react" style="width:30.2%"></span>
         <span class="bar-value">60 KB</span></span>
       </div>
       <div class="bar-row" data-tip="Preact: 9 KB gzipped · 22 KB raw · 1 file(s)">
         <span class="bar-name">Preact</span>
-        <span class="bar-track"><span class="bar" data-fw="preact" style="width:8.9%"></span>
+        <span class="bar-track"><span class="bar" data-fw="preact" style="width:4.3%"></span>
         <span class="bar-value">9 KB</span></span>
       </div>
       <div class="bar-row" data-tip="Vue: 65 KB gzipped · 174 KB raw · 1 file(s)">
         <span class="bar-name">Vue</span>
-        <span class="bar-track"><span class="bar" data-fw="vue" style="width:67.7%"></span>
+        <span class="bar-track"><span class="bar" data-fw="vue" style="width:32.7%"></span>
         <span class="bar-value">65 KB</span></span>
       </div>
       <div class="bar-row" data-tip="Svelte: 21 KB gzipped · 55 KB raw · 1 file(s)">
         <span class="bar-name">Svelte</span>
-        <span class="bar-track"><span class="bar" data-fw="svelte" style="width:21.5%"></span>
+        <span class="bar-track"><span class="bar" data-fw="svelte" style="width:10.4%"></span>
         <span class="bar-value">21 KB</span></span>
       </div>
       <div class="bar-row" data-tip="Vanilla JS: 1 KB gzipped · 3 KB raw · 1 file(s)">
         <span class="bar-name">Vanilla JS</span>
-        <span class="bar-track"><span class="bar" data-fw="vanilla" style="width:1.3%"></span>
+        <span class="bar-track"><span class="bar" data-fw="vanilla" style="width:0.8%"></span>
         <span class="bar-value">1 KB</span></span>
+      </div>
+      <div class="bar-row" data-tip="Compose HTML: 171 KB gzipped · 534 KB raw · 1 file(s)">
+        <span class="bar-name">Compose HTML</span>
+        <span class="bar-track"><span class="bar" data-fw="compose-web" style="width:86.0%"></span>
+        <span class="bar-value">171 KB</span></span>
       </div></div>
 
   </figure>
@@ -1205,33 +1388,38 @@ footer { margin-top: 48px; color: var(--muted); font-size: 12.5px; }
     <div class="bars" data-unit="ms">
       <div class="bar-row" data-tip="Kinetica: median 24.5ms over 5 cold loads (24, 26, 26, 24, 25) · script compile+evaluate 7.0ms · blocking time 0.0ms">
         <span class="bar-name">Kinetica</span>
-        <span class="bar-track"><span class="bar" data-fw="kinetica" style="width:77.2%"></span>
+        <span class="bar-track"><span class="bar" data-fw="kinetica" style="width:38.1%"></span>
         <span class="bar-value">24.5 ms</span></span>
       </div>
       <div class="bar-row" data-tip="React: median 27.3ms over 5 cold loads (28, 26, 28, 27, 27) · script compile+evaluate 12.4ms · blocking time 0.0ms">
         <span class="bar-name">React</span>
-        <span class="bar-track"><span class="bar" data-fw="react" style="width:86.0%"></span>
+        <span class="bar-track"><span class="bar" data-fw="react" style="width:42.5%"></span>
         <span class="bar-value">27.3 ms</span></span>
       </div>
       <div class="bar-row" data-tip="Preact: median 15.2ms over 5 cold loads (15, 16, 15, 16, 15) · script compile+evaluate 7.0ms · blocking time 0.0ms">
         <span class="bar-name">Preact</span>
-        <span class="bar-track"><span class="bar" data-fw="preact" style="width:47.9%"></span>
+        <span class="bar-track"><span class="bar" data-fw="preact" style="width:23.6%"></span>
         <span class="bar-value">15.2 ms</span></span>
       </div>
       <div class="bar-row" data-tip="Vue: median 21.4ms over 5 cold loads (21, 22, 21, 23, 21) · script compile+evaluate 9.9ms · blocking time 0.0ms">
         <span class="bar-name">Vue</span>
-        <span class="bar-track"><span class="bar" data-fw="vue" style="width:67.4%"></span>
+        <span class="bar-track"><span class="bar" data-fw="vue" style="width:33.3%"></span>
         <span class="bar-value">21.4 ms</span></span>
       </div>
       <div class="bar-row" data-tip="Svelte: median 16.4ms over 5 cold loads (16, 18, 16, 17, 16) · script compile+evaluate 8.1ms · blocking time 0.0ms">
         <span class="bar-name">Svelte</span>
-        <span class="bar-track"><span class="bar" data-fw="svelte" style="width:51.7%"></span>
+        <span class="bar-track"><span class="bar" data-fw="svelte" style="width:25.5%"></span>
         <span class="bar-value">16.4 ms</span></span>
       </div>
       <div class="bar-row" data-tip="Vanilla JS: median 17.5ms over 5 cold loads (16, 19, 20, 16, 18) · script compile+evaluate 7.4ms · blocking time 0.0ms">
         <span class="bar-name">Vanilla JS</span>
-        <span class="bar-track"><span class="bar" data-fw="vanilla" style="width:55.1%"></span>
+        <span class="bar-track"><span class="bar" data-fw="vanilla" style="width:27.2%"></span>
         <span class="bar-value">17.5 ms</span></span>
+      </div>
+      <div class="bar-row" data-tip="Compose HTML: median 55.3ms over 5 cold loads (60, 54, 55, 56, 54) · script compile+evaluate 16.0ms · blocking time 0.0ms">
+        <span class="bar-name">Compose HTML</span>
+        <span class="bar-track"><span class="bar" data-fw="compose-web" style="width:86.0%"></span>
+        <span class="bar-value">55.3 ms</span></span>
       </div></div>
 
   </figure>
@@ -1240,33 +1428,38 @@ footer { margin-top: 48px; color: var(--muted); font-size: 12.5px; }
     <div class="bars" data-unit="ms">
       <div class="bar-row" data-tip="Kinetica: 7.0ms compile+evaluate · ~0.0ms long-task blocking before mount">
         <span class="bar-name">Kinetica</span>
-        <span class="bar-track"><span class="bar" data-fw="kinetica" style="width:48.9%"></span>
+        <span class="bar-track"><span class="bar" data-fw="kinetica" style="width:37.7%"></span>
         <span class="bar-value">7.0 ms</span></span>
       </div>
       <div class="bar-row" data-tip="React: 12.4ms compile+evaluate · ~0.0ms long-task blocking before mount">
         <span class="bar-name">React</span>
-        <span class="bar-track"><span class="bar" data-fw="react" style="width:86.0%"></span>
+        <span class="bar-track"><span class="bar" data-fw="react" style="width:66.3%"></span>
         <span class="bar-value">12.4 ms</span></span>
       </div>
       <div class="bar-row" data-tip="Preact: 7.0ms compile+evaluate · ~0.0ms long-task blocking before mount">
         <span class="bar-name">Preact</span>
-        <span class="bar-track"><span class="bar" data-fw="preact" style="width:48.8%"></span>
+        <span class="bar-track"><span class="bar" data-fw="preact" style="width:37.6%"></span>
         <span class="bar-value">7.0 ms</span></span>
       </div>
       <div class="bar-row" data-tip="Vue: 9.9ms compile+evaluate · ~0.0ms long-task blocking before mount">
         <span class="bar-name">Vue</span>
-        <span class="bar-track"><span class="bar" data-fw="vue" style="width:68.8%"></span>
+        <span class="bar-track"><span class="bar" data-fw="vue" style="width:53.1%"></span>
         <span class="bar-value">9.9 ms</span></span>
       </div>
       <div class="bar-row" data-tip="Svelte: 8.1ms compile+evaluate · ~0.0ms long-task blocking before mount">
         <span class="bar-name">Svelte</span>
-        <span class="bar-track"><span class="bar" data-fw="svelte" style="width:56.4%"></span>
+        <span class="bar-track"><span class="bar" data-fw="svelte" style="width:43.5%"></span>
         <span class="bar-value">8.1 ms</span></span>
       </div>
       <div class="bar-row" data-tip="Vanilla JS: 7.4ms compile+evaluate · ~0.0ms long-task blocking before mount">
         <span class="bar-name">Vanilla JS</span>
-        <span class="bar-track"><span class="bar" data-fw="vanilla" style="width:51.5%"></span>
+        <span class="bar-track"><span class="bar" data-fw="vanilla" style="width:39.7%"></span>
         <span class="bar-value">7.4 ms</span></span>
+      </div>
+      <div class="bar-row" data-tip="Compose HTML: 16.0ms compile+evaluate · ~0.0ms long-task blocking before mount">
+        <span class="bar-name">Compose HTML</span>
+        <span class="bar-track"><span class="bar" data-fw="compose-web" style="width:86.0%"></span>
+        <span class="bar-value">16.0 ms</span></span>
       </div></div>
 
   </figure>
@@ -1275,33 +1468,38 @@ footer { margin-top: 48px; color: var(--muted); font-size: 12.5px; }
     <div class="bars" data-unit="MB">
       <div class="bar-row" data-tip="Kinetica: 6.5 MB after 1k rows · 2.0 MB right after load">
         <span class="bar-name">Kinetica</span>
-        <span class="bar-track"><span class="bar" data-fw="kinetica" style="width:86.0%"></span>
+        <span class="bar-track"><span class="bar" data-fw="kinetica" style="width:31.2%"></span>
         <span class="bar-value">6.5 MB</span></span>
       </div>
       <div class="bar-row" data-tip="React: 4.4 MB after 1k rows · 1.6 MB right after load">
         <span class="bar-name">React</span>
-        <span class="bar-track"><span class="bar" data-fw="react" style="width:58.4%"></span>
+        <span class="bar-track"><span class="bar" data-fw="react" style="width:21.2%"></span>
         <span class="bar-value">4.4 MB</span></span>
       </div>
       <div class="bar-row" data-tip="Preact: 4.3 MB after 1k rows · 1.3 MB right after load">
         <span class="bar-name">Preact</span>
-        <span class="bar-track"><span class="bar" data-fw="preact" style="width:56.8%"></span>
+        <span class="bar-track"><span class="bar" data-fw="preact" style="width:20.6%"></span>
         <span class="bar-value">4.3 MB</span></span>
       </div>
       <div class="bar-row" data-tip="Vue: 4.4 MB after 1k rows · 1.9 MB right after load">
         <span class="bar-name">Vue</span>
-        <span class="bar-track"><span class="bar" data-fw="vue" style="width:58.8%"></span>
+        <span class="bar-track"><span class="bar" data-fw="vue" style="width:21.4%"></span>
         <span class="bar-value">4.4 MB</span></span>
       </div>
       <div class="bar-row" data-tip="Svelte: 3.2 MB after 1k rows · 1.3 MB right after load">
         <span class="bar-name">Svelte</span>
-        <span class="bar-track"><span class="bar" data-fw="svelte" style="width:43.0%"></span>
+        <span class="bar-track"><span class="bar" data-fw="svelte" style="width:15.6%"></span>
         <span class="bar-value">3.2 MB</span></span>
       </div>
       <div class="bar-row" data-tip="Vanilla JS: 1.9 MB after 1k rows · 1.2 MB right after load">
         <span class="bar-name">Vanilla JS</span>
-        <span class="bar-track"><span class="bar" data-fw="vanilla" style="width:25.2%"></span>
+        <span class="bar-track"><span class="bar" data-fw="vanilla" style="width:9.2%"></span>
         <span class="bar-value">1.9 MB</span></span>
+      </div>
+      <div class="bar-row" data-tip="Compose HTML: 17.8 MB after 1k rows · 2.7 MB right after load">
+        <span class="bar-name">Compose HTML</span>
+        <span class="bar-track"><span class="bar" data-fw="compose-web" style="width:86.0%"></span>
+        <span class="bar-value">17.8 MB</span></span>
       </div></div>
 
   </figure></div>
@@ -1315,7 +1513,7 @@ footer { margin-top: 48px; color: var(--muted); font-size: 12.5px; }
         <thead>
           <tr><th></th><th scope="col">after load</th><th scope="col">1k rows</th><th scope="col">5× replace</th><th scope="col">10× create+clear</th><th scope="col">unmounted</th><th scope="col">5× remount cycles</th></tr>
         </thead>
-        <tbody><tr><th scope="row"><span class="swatch" data-fw="kinetica"></span> Kinetica</th><td class="num " title="Kinetica · heap after load: 2.0 MB">2.0</td><td class="num " title="Kinetica · heap 1k rows: 6.5 MB">6.5</td><td class="num " title="Kinetica · heap 5× replace: 6.9 MB">6.9</td><td class="num " title="Kinetica · heap 10× create+clear: 3.6 MB">3.6</td><td class="num " title="Kinetica · heap unmounted: 3.5 MB">3.5</td><td class="num " title="Kinetica · heap 5× remount cycles: 3.6 MB (+0.1 MB vs first unmount)">3.6</td></tr><tr><th scope="row"><span class="swatch" data-fw="react"></span> React</th><td class="num " title="React · heap after load: 1.6 MB">1.6</td><td class="num " title="React · heap 1k rows: 4.4 MB">4.4</td><td class="num " title="React · heap 5× replace: 5.0 MB">5.0</td><td class="num " title="React · heap 10× create+clear: 3.2 MB">3.2</td><td class="num " title="React · heap unmounted: 2.9 MB">2.9</td><td class="num " title="React · heap 5× remount cycles: 2.8 MB (-0.0 MB vs first unmount)">2.8</td></tr><tr><th scope="row"><span class="swatch" data-fw="preact"></span> Preact</th><td class="num " title="Preact · heap after load: 1.3 MB">1.3</td><td class="num " title="Preact · heap 1k rows: 4.3 MB">4.3</td><td class="num " title="Preact · heap 5× replace: 4.4 MB">4.4</td><td class="num " title="Preact · heap 10× create+clear: 2.2 MB">2.2</td><td class="num " title="Preact · heap unmounted: 2.1 MB">2.1</td><td class="num " title="Preact · heap 5× remount cycles: 2.1 MB (-0.0 MB vs first unmount)">2.1</td></tr><tr><th scope="row"><span class="swatch" data-fw="vue"></span> Vue</th><td class="num " title="Vue · heap after load: 1.9 MB">1.9</td><td class="num " title="Vue · heap 1k rows: 4.4 MB">4.4</td><td class="num " title="Vue · heap 5× replace: 4.6 MB">4.6</td><td class="num " title="Vue · heap 10× create+clear: 2.9 MB">2.9</td><td class="num " title="Vue · heap unmounted: 2.9 MB">2.9</td><td class="num " title="Vue · heap 5× remount cycles: 2.9 MB (-0.0 MB vs first unmount)">2.9</td></tr><tr><th scope="row"><span class="swatch" data-fw="svelte"></span> Svelte</th><td class="num " title="Svelte · heap after load: 1.3 MB">1.3</td><td class="num " title="Svelte · heap 1k rows: 3.2 MB">3.2</td><td class="num " title="Svelte · heap 5× replace: 3.4 MB">3.4</td><td class="num " title="Svelte · heap 10× create+clear: 2.4 MB">2.4</td><td class="num " title="Svelte · heap unmounted: 2.4 MB">2.4</td><td class="num " title="Svelte · heap 5× remount cycles: 2.4 MB (+0.0 MB vs first unmount)">2.4</td></tr><tr><th scope="row"><span class="swatch" data-fw="vanilla"></span> Vanilla JS</th><td class="num " title="Vanilla JS · heap after load: 1.2 MB">1.2</td><td class="num " title="Vanilla JS · heap 1k rows: 1.9 MB">1.9</td><td class="num " title="Vanilla JS · heap 5× replace: 2.0 MB">2.0</td><td class="num " title="Vanilla JS · heap 10× create+clear: 1.9 MB">1.9</td><td class="num " title="Vanilla JS · heap unmounted: 1.9 MB">1.9</td><td class="num " title="Vanilla JS · heap 5× remount cycles: 1.9 MB (+0.0 MB vs first unmount)">1.9</td></tr></tbody>
+        <tbody><tr><th scope="row"><span class="swatch" data-fw="kinetica"></span> Kinetica</th><td class="num " title="Kinetica · heap after load: 2.0 MB">2.0</td><td class="num " title="Kinetica · heap 1k rows: 6.5 MB">6.5</td><td class="num " title="Kinetica · heap 5× replace: 6.9 MB">6.9</td><td class="num " title="Kinetica · heap 10× create+clear: 3.6 MB">3.6</td><td class="num " title="Kinetica · heap unmounted: 3.5 MB">3.5</td><td class="num " title="Kinetica · heap 5× remount cycles: 3.6 MB (+0.1 MB vs first unmount)">3.6</td></tr><tr><th scope="row"><span class="swatch" data-fw="react"></span> React</th><td class="num " title="React · heap after load: 1.6 MB">1.6</td><td class="num " title="React · heap 1k rows: 4.4 MB">4.4</td><td class="num " title="React · heap 5× replace: 5.0 MB">5.0</td><td class="num " title="React · heap 10× create+clear: 3.2 MB">3.2</td><td class="num " title="React · heap unmounted: 2.9 MB">2.9</td><td class="num " title="React · heap 5× remount cycles: 2.8 MB (-0.0 MB vs first unmount)">2.8</td></tr><tr><th scope="row"><span class="swatch" data-fw="preact"></span> Preact</th><td class="num " title="Preact · heap after load: 1.3 MB">1.3</td><td class="num " title="Preact · heap 1k rows: 4.3 MB">4.3</td><td class="num " title="Preact · heap 5× replace: 4.4 MB">4.4</td><td class="num " title="Preact · heap 10× create+clear: 2.2 MB">2.2</td><td class="num " title="Preact · heap unmounted: 2.1 MB">2.1</td><td class="num " title="Preact · heap 5× remount cycles: 2.1 MB (-0.0 MB vs first unmount)">2.1</td></tr><tr><th scope="row"><span class="swatch" data-fw="vue"></span> Vue</th><td class="num " title="Vue · heap after load: 1.9 MB">1.9</td><td class="num " title="Vue · heap 1k rows: 4.4 MB">4.4</td><td class="num " title="Vue · heap 5× replace: 4.6 MB">4.6</td><td class="num " title="Vue · heap 10× create+clear: 2.9 MB">2.9</td><td class="num " title="Vue · heap unmounted: 2.9 MB">2.9</td><td class="num " title="Vue · heap 5× remount cycles: 2.9 MB (-0.0 MB vs first unmount)">2.9</td></tr><tr><th scope="row"><span class="swatch" data-fw="svelte"></span> Svelte</th><td class="num " title="Svelte · heap after load: 1.3 MB">1.3</td><td class="num " title="Svelte · heap 1k rows: 3.2 MB">3.2</td><td class="num " title="Svelte · heap 5× replace: 3.4 MB">3.4</td><td class="num " title="Svelte · heap 10× create+clear: 2.4 MB">2.4</td><td class="num " title="Svelte · heap unmounted: 2.4 MB">2.4</td><td class="num " title="Svelte · heap 5× remount cycles: 2.4 MB (+0.0 MB vs first unmount)">2.4</td></tr><tr><th scope="row"><span class="swatch" data-fw="vanilla"></span> Vanilla JS</th><td class="num " title="Vanilla JS · heap after load: 1.2 MB">1.2</td><td class="num " title="Vanilla JS · heap 1k rows: 1.9 MB">1.9</td><td class="num " title="Vanilla JS · heap 5× replace: 2.0 MB">2.0</td><td class="num " title="Vanilla JS · heap 10× create+clear: 1.9 MB">1.9</td><td class="num " title="Vanilla JS · heap unmounted: 1.9 MB">1.9</td><td class="num " title="Vanilla JS · heap 5× remount cycles: 1.9 MB (+0.0 MB vs first unmount)">1.9</td></tr><tr><th scope="row"><span class="swatch" data-fw="compose-web"></span> Compose HTML</th><td class="num " title="Compose HTML · heap after load: 2.7 MB">2.7</td><td class="num " title="Compose HTML · heap 1k rows: 17.8 MB">17.8</td><td class="num " title="Compose HTML · heap 5× replace: 19.5 MB">19.5</td><td class="num " title="Compose HTML · heap 10× create+clear: 7.3 MB">7.3</td><td class="num " title="Compose HTML · heap unmounted: 4.7 MB">4.7</td><td class="num " title="Compose HTML · heap 5× remount cycles: 4.9 MB (+0.2 MB vs first unmount)">4.9</td></tr></tbody>
       </table>
     </div>
     <div class="callout">
@@ -1381,7 +1579,7 @@ footer { margin-top: 48px; color: var(--muted); font-size: 12.5px; }
 
   <footer>
     Generated 2026-07-06 21:00 UTC ·
-    versions: Kinetica dev · React 19.2.7 · Preact 10.29.4 · Vue 3.5.39 · Svelte 5.56.4 · Vanilla JS n/a ·
+    versions: Kinetica dev · React 19.2.7 · Preact 10.29.4 · Vue 3.5.39 · Svelte 5.56.4 · Vanilla JS n/a · Compose HTML 1.11.1 ·
     raw data in <code>bench/results/results.json</code>
   </footer>
 </div>

--- a/bench/results/part-compose-web.json
+++ b/bench/results/part-compose-web.json
@@ -1,0 +1,354 @@
+{
+  "meta": {
+    "date": "2026-07-07T19:24:47.786Z",
+    "machine": {
+      "cpu": "Apple M4 Max",
+      "arch": "arm64",
+      "platform": "darwin",
+      "memGb": 36
+    },
+    "chromium": "149.0.7827.55",
+    "warmup": 1,
+    "samples": 5,
+    "cpuThrottle": null,
+    "methodology": "Playwright trusted clicks; per-operation Chrome trace (devtools.timeline); duration = click EventDispatch start -> end of last Paint/Commit event; headless Chrome for Testing; local static server. No CPU throttling.",
+    "versions": {
+      "compose-web": "1.11.1"
+    }
+  },
+  "benchmarks": [
+    {
+      "id": "01_run1k",
+      "label": "create 1,000 rows"
+    },
+    {
+      "id": "02_replace1k",
+      "label": "replace all 1,000 rows"
+    },
+    {
+      "id": "03_update10th1k",
+      "label": "partial update (every 10th row)"
+    },
+    {
+      "id": "04_select1k",
+      "label": "select row"
+    },
+    {
+      "id": "05_swap1k",
+      "label": "swap two rows"
+    },
+    {
+      "id": "06_remove1k",
+      "label": "remove one row"
+    },
+    {
+      "id": "07_create10k",
+      "label": "create 10,000 rows"
+    },
+    {
+      "id": "08_append1k",
+      "label": "append 1,000 rows to 1,000"
+    },
+    {
+      "id": "09_clear1k",
+      "label": "clear 1,000 rows"
+    },
+    {
+      "id": "10_select10k",
+      "label": "select row (10k table)"
+    },
+    {
+      "id": "11_swap10k",
+      "label": "swap two rows (10k table)"
+    },
+    {
+      "id": "12_remove10k",
+      "label": "remove one row (10k table)"
+    },
+    {
+      "id": "13_update10th10k",
+      "label": "partial update (every 10th of 10k)"
+    }
+  ],
+  "results": {
+    "compose-web": {
+      "01_run1k": {
+        "samples": [
+          251.44,
+          237.65,
+          222.63,
+          229.43,
+          249.6
+        ],
+        "median": 237.65,
+        "mean": 238.15,
+        "stddev": 11.18,
+        "min": 222.63,
+        "max": 251.44,
+        "gcMedianMs": 59.33,
+        "gcMaxMs": 63.98,
+        "gcMeanCount": 251,
+        "pageErrors": 0
+      },
+      "02_replace1k": {
+        "samples": [
+          388.21,
+          356.1,
+          363.85,
+          354.41,
+          362.03
+        ],
+        "median": 362.03,
+        "mean": 364.92,
+        "stddev": 12.17,
+        "min": 354.41,
+        "max": 388.21,
+        "gcMedianMs": 76.44,
+        "gcMaxMs": 119.53,
+        "gcMeanCount": 791.8,
+        "pageErrors": 0
+      },
+      "03_update10th1k": {
+        "samples": [
+          15.26,
+          13.49,
+          12.92,
+          12.57,
+          9.56
+        ],
+        "median": 12.92,
+        "mean": 12.76,
+        "stddev": 1.85,
+        "min": 9.56,
+        "max": 15.26,
+        "gcMedianMs": 0,
+        "gcMaxMs": 0,
+        "gcMeanCount": 0,
+        "pageErrors": 0
+      },
+      "04_select1k": {
+        "samples": [
+          10.66,
+          9.19,
+          10.87,
+          10.47,
+          9.4
+        ],
+        "median": 10.47,
+        "mean": 10.12,
+        "stddev": 0.69,
+        "min": 9.19,
+        "max": 10.87,
+        "gcMedianMs": 0,
+        "gcMaxMs": 0,
+        "gcMeanCount": 0,
+        "pageErrors": 0
+      },
+      "05_swap1k": {
+        "samples": [
+          565.58,
+          561.81,
+          560.87,
+          562.14,
+          555.7
+        ],
+        "median": 561.81,
+        "mean": 561.22,
+        "stddev": 3.19,
+        "min": 555.7,
+        "max": 565.58,
+        "gcMedianMs": 7.16,
+        "gcMaxMs": 8.49,
+        "gcMeanCount": 247.4,
+        "pageErrors": 0
+      },
+      "06_remove1k": {
+        "samples": [
+          525.92,
+          520.76,
+          533.61,
+          516.88,
+          521.97
+        ],
+        "median": 521.97,
+        "mean": 523.83,
+        "stddev": 5.68,
+        "min": 516.88,
+        "max": 533.61,
+        "gcMedianMs": 7.67,
+        "gcMaxMs": 11.26,
+        "gcMeanCount": 137.8,
+        "pageErrors": 0
+      },
+      "07_create10k": {
+        "samples": [
+          7909.4,
+          8092.02,
+          7995.57,
+          8108.51,
+          7946.44
+        ],
+        "median": 7995.57,
+        "mean": 8010.39,
+        "stddev": 78.49,
+        "min": 7909.4,
+        "max": 8108.51,
+        "gcMedianMs": 1346.07,
+        "gcMaxMs": 1415.94,
+        "gcMeanCount": 9581.4,
+        "pageErrors": 0
+      },
+      "08_append1k": {
+        "samples": [
+          240.96,
+          232.39,
+          234.59,
+          232.56,
+          233.09
+        ],
+        "median": 233.09,
+        "mean": 234.72,
+        "stddev": 3.22,
+        "min": 232.39,
+        "max": 240.96,
+        "gcMedianMs": 55.78,
+        "gcMaxMs": 65.4,
+        "gcMeanCount": 229.6,
+        "pageErrors": 0
+      },
+      "09_clear1k": {
+        "samples": [
+          23.43,
+          27.62,
+          32.53,
+          24.06,
+          20.37
+        ],
+        "median": 24.06,
+        "mean": 25.6,
+        "stddev": 4.16,
+        "min": 20.37,
+        "max": 32.53,
+        "gcMedianMs": 0,
+        "gcMaxMs": 0,
+        "gcMeanCount": 0,
+        "pageErrors": 0
+      },
+      "10_select10k": {
+        "samples": [
+          24.98,
+          31.53,
+          23.29,
+          21.29,
+          29.15
+        ],
+        "median": 24.98,
+        "mean": 26.05,
+        "stddev": 3.77,
+        "min": 21.29,
+        "max": 31.53,
+        "gcMedianMs": 18.47,
+        "gcMaxMs": 27.35,
+        "gcMeanCount": 30.8,
+        "pageErrors": 0
+      },
+      "11_swap10k": {
+        "samples": [
+          9575.96,
+          9508.93,
+          9416.61,
+          9554.35,
+          9570.21
+        ],
+        "median": 9554.35,
+        "mean": 9525.21,
+        "stddev": 59.18,
+        "min": 9416.61,
+        "max": 9575.96,
+        "gcMedianMs": 83.46,
+        "gcMaxMs": 156.92,
+        "gcMeanCount": 2290,
+        "pageErrors": 0
+      },
+      "12_remove10k": {
+        "samples": [
+          49289.44,
+          49329.49,
+          49939.31,
+          50205.02,
+          49552.83
+        ],
+        "median": 49552.83,
+        "mean": 49663.22,
+        "stddev": 355.82,
+        "min": 49289.44,
+        "max": 50205.02,
+        "gcMedianMs": 384.27,
+        "gcMaxMs": 429.79,
+        "gcMeanCount": 6763,
+        "pageErrors": 0
+      },
+      "13_update10th10k": {
+        "samples": [
+          133.05,
+          98.23,
+          99.5,
+          143.29,
+          130.04
+        ],
+        "median": 130.04,
+        "mean": 120.82,
+        "stddev": 18.46,
+        "min": 98.23,
+        "max": 143.29,
+        "gcMedianMs": 29.87,
+        "gcMaxMs": 45.61,
+        "gcMeanCount": 39.4,
+        "pageErrors": 0
+      }
+    }
+  },
+  "startup": {
+    "compose-web": {
+      "mountMs": [
+        60.3,
+        54.2,
+        55.3,
+        56.2,
+        53.7
+      ],
+      "median": 55.3,
+      "mean": 55.94,
+      "stddev": 2.35,
+      "min": 53.7,
+      "max": 60.3,
+      "jsBytes": 547292,
+      "gzipBytes": 175569,
+      "files": 1,
+      "scriptMs": 16.04,
+      "tbtMs": 0
+    }
+  },
+  "memory": {
+    "compose-web": {
+      "afterLoadMb": 2.73,
+      "after1kMb": 17.84,
+      "after5xReplaceMb": 19.52,
+      "afterCreateClear10Mb": 7.31,
+      "afterUnmountMb": 4.66,
+      "after5xRemountMb": 4.85
+    }
+  },
+  "animation": {
+    "compose-web": {
+      "seconds": 6,
+      "frames": 665,
+      "fps": 119.64,
+      "meanMs": 8.36,
+      "medianMs": 8.3,
+      "p95Ms": 9.3,
+      "longFramePct": 0,
+      "pageErrors": 0
+    }
+  }
+}

--- a/bench/results/results.json
+++ b/bench/results/results.json
@@ -18,7 +18,8 @@
       "preact": "10.29.4",
       "vue": "3.5.39",
       "svelte": "5.56.4",
-      "vanilla": "n/a"
+      "vanilla": "n/a",
+      "compose-web": "1.11.1"
     }
   },
   "benchmarks": [
@@ -1881,6 +1882,242 @@
         "gcMeanCount": 0,
         "pageErrors": 0
       }
+    },
+    "compose-web": {
+      "01_run1k": {
+        "samples": [
+          251.44,
+          237.65,
+          222.63,
+          229.43,
+          249.6
+        ],
+        "median": 237.65,
+        "mean": 238.15,
+        "stddev": 11.18,
+        "min": 222.63,
+        "max": 251.44,
+        "gcMedianMs": 59.33,
+        "gcMaxMs": 63.98,
+        "gcMeanCount": 251,
+        "pageErrors": 0
+      },
+      "02_replace1k": {
+        "samples": [
+          388.21,
+          356.1,
+          363.85,
+          354.41,
+          362.03
+        ],
+        "median": 362.03,
+        "mean": 364.92,
+        "stddev": 12.17,
+        "min": 354.41,
+        "max": 388.21,
+        "gcMedianMs": 76.44,
+        "gcMaxMs": 119.53,
+        "gcMeanCount": 791.8,
+        "pageErrors": 0
+      },
+      "03_update10th1k": {
+        "samples": [
+          15.26,
+          13.49,
+          12.92,
+          12.57,
+          9.56
+        ],
+        "median": 12.92,
+        "mean": 12.76,
+        "stddev": 1.85,
+        "min": 9.56,
+        "max": 15.26,
+        "gcMedianMs": 0,
+        "gcMaxMs": 0,
+        "gcMeanCount": 0,
+        "pageErrors": 0
+      },
+      "04_select1k": {
+        "samples": [
+          10.66,
+          9.19,
+          10.87,
+          10.47,
+          9.4
+        ],
+        "median": 10.47,
+        "mean": 10.12,
+        "stddev": 0.69,
+        "min": 9.19,
+        "max": 10.87,
+        "gcMedianMs": 0,
+        "gcMaxMs": 0,
+        "gcMeanCount": 0,
+        "pageErrors": 0
+      },
+      "05_swap1k": {
+        "samples": [
+          565.58,
+          561.81,
+          560.87,
+          562.14,
+          555.7
+        ],
+        "median": 561.81,
+        "mean": 561.22,
+        "stddev": 3.19,
+        "min": 555.7,
+        "max": 565.58,
+        "gcMedianMs": 7.16,
+        "gcMaxMs": 8.49,
+        "gcMeanCount": 247.4,
+        "pageErrors": 0
+      },
+      "06_remove1k": {
+        "samples": [
+          525.92,
+          520.76,
+          533.61,
+          516.88,
+          521.97
+        ],
+        "median": 521.97,
+        "mean": 523.83,
+        "stddev": 5.68,
+        "min": 516.88,
+        "max": 533.61,
+        "gcMedianMs": 7.67,
+        "gcMaxMs": 11.26,
+        "gcMeanCount": 137.8,
+        "pageErrors": 0
+      },
+      "07_create10k": {
+        "samples": [
+          7909.4,
+          8092.02,
+          7995.57,
+          8108.51,
+          7946.44
+        ],
+        "median": 7995.57,
+        "mean": 8010.39,
+        "stddev": 78.49,
+        "min": 7909.4,
+        "max": 8108.51,
+        "gcMedianMs": 1346.07,
+        "gcMaxMs": 1415.94,
+        "gcMeanCount": 9581.4,
+        "pageErrors": 0
+      },
+      "08_append1k": {
+        "samples": [
+          240.96,
+          232.39,
+          234.59,
+          232.56,
+          233.09
+        ],
+        "median": 233.09,
+        "mean": 234.72,
+        "stddev": 3.22,
+        "min": 232.39,
+        "max": 240.96,
+        "gcMedianMs": 55.78,
+        "gcMaxMs": 65.4,
+        "gcMeanCount": 229.6,
+        "pageErrors": 0
+      },
+      "09_clear1k": {
+        "samples": [
+          23.43,
+          27.62,
+          32.53,
+          24.06,
+          20.37
+        ],
+        "median": 24.06,
+        "mean": 25.6,
+        "stddev": 4.16,
+        "min": 20.37,
+        "max": 32.53,
+        "gcMedianMs": 0,
+        "gcMaxMs": 0,
+        "gcMeanCount": 0,
+        "pageErrors": 0
+      },
+      "10_select10k": {
+        "samples": [
+          24.98,
+          31.53,
+          23.29,
+          21.29,
+          29.15
+        ],
+        "median": 24.98,
+        "mean": 26.05,
+        "stddev": 3.77,
+        "min": 21.29,
+        "max": 31.53,
+        "gcMedianMs": 18.47,
+        "gcMaxMs": 27.35,
+        "gcMeanCount": 30.8,
+        "pageErrors": 0
+      },
+      "11_swap10k": {
+        "samples": [
+          9575.96,
+          9508.93,
+          9416.61,
+          9554.35,
+          9570.21
+        ],
+        "median": 9554.35,
+        "mean": 9525.21,
+        "stddev": 59.18,
+        "min": 9416.61,
+        "max": 9575.96,
+        "gcMedianMs": 83.46,
+        "gcMaxMs": 156.92,
+        "gcMeanCount": 2290,
+        "pageErrors": 0
+      },
+      "12_remove10k": {
+        "samples": [
+          49289.44,
+          49329.49,
+          49939.31,
+          50205.02,
+          49552.83
+        ],
+        "median": 49552.83,
+        "mean": 49663.22,
+        "stddev": 355.82,
+        "min": 49289.44,
+        "max": 50205.02,
+        "gcMedianMs": 384.27,
+        "gcMaxMs": 429.79,
+        "gcMeanCount": 6763,
+        "pageErrors": 0
+      },
+      "13_update10th10k": {
+        "samples": [
+          133.05,
+          98.23,
+          99.5,
+          143.29,
+          130.04
+        ],
+        "median": 130.04,
+        "mean": 120.82,
+        "stddev": 18.46,
+        "min": 98.23,
+        "max": 143.29,
+        "gcMedianMs": 29.87,
+        "gcMaxMs": 45.61,
+        "gcMeanCount": 39.4,
+        "pageErrors": 0
+      }
     }
   },
   "startup": {
@@ -1997,6 +2234,25 @@
       "files": 1,
       "scriptMs": 7.41,
       "tbtMs": 0
+    },
+    "compose-web": {
+      "mountMs": [
+        60.3,
+        54.2,
+        55.3,
+        56.2,
+        53.7
+      ],
+      "median": 55.3,
+      "mean": 55.94,
+      "stddev": 2.35,
+      "min": 53.7,
+      "max": 60.3,
+      "jsBytes": 547292,
+      "gzipBytes": 175569,
+      "files": 1,
+      "scriptMs": 16.04,
+      "tbtMs": 0
     }
   },
   "memory": {
@@ -2047,6 +2303,14 @@
       "afterCreateClear10Mb": 1.92,
       "afterUnmountMb": 1.92,
       "after5xRemountMb": 1.92
+    },
+    "compose-web": {
+      "afterLoadMb": 2.73,
+      "after1kMb": 17.84,
+      "after5xReplaceMb": 19.52,
+      "afterCreateClear10Mb": 7.31,
+      "afterUnmountMb": 4.66,
+      "after5xRemountMb": 4.85
     }
   },
   "animation": {
@@ -2105,6 +2369,16 @@
       "frames": 665,
       "fps": 120,
       "meanMs": 8.33,
+      "medianMs": 8.3,
+      "p95Ms": 9.3,
+      "longFramePct": 0,
+      "pageErrors": 0
+    },
+    "compose-web": {
+      "seconds": 6,
+      "frames": 665,
+      "fps": 119.64,
+      "meanMs": 8.36,
       "medianMs": 8.3,
       "p95Ms": 9.3,
       "longFramePct": 0,

--- a/bench/results/tree.json
+++ b/bench/results/tree.json
@@ -541,6 +541,72 @@
         "gcMedianMs": 0,
         "pageErrors": 0
       }
+    },
+    "compose-web": {
+      "t1_createTree": {
+        "samples": [
+          53.78,
+          57.72,
+          46.1,
+          47.13,
+          50.26
+        ],
+        "median": 50.26,
+        "mean": 51,
+        "stddev": 4.3,
+        "min": 46.1,
+        "max": 57.72,
+        "gcMedianMs": 23.89,
+        "pageErrors": 0
+      },
+      "t2_updateLeaves": {
+        "samples": [
+          13.34,
+          13.75,
+          12.73,
+          12.52,
+          12.31
+        ],
+        "median": 12.73,
+        "mean": 12.93,
+        "stddev": 0.54,
+        "min": 12.31,
+        "max": 13.75,
+        "gcMedianMs": 0,
+        "pageErrors": 0
+      },
+      "t3_reverseTop": {
+        "samples": [
+          16.47,
+          16.12,
+          15.79,
+          16.23,
+          14.78
+        ],
+        "median": 16.12,
+        "mean": 15.88,
+        "stddev": 0.59,
+        "min": 14.78,
+        "max": 16.47,
+        "gcMedianMs": 0,
+        "pageErrors": 0
+      },
+      "t4_noopRender": {
+        "samples": [
+          8.38,
+          8.65,
+          5.26,
+          7.86,
+          7.9
+        ],
+        "median": 7.9,
+        "mean": 7.61,
+        "stddev": 1.21,
+        "min": 5.26,
+        "max": 8.65,
+        "gcMedianMs": 0,
+        "pageErrors": 0
+      }
     }
   }
 }

--- a/bench/results/tree/part-compose-web.json
+++ b/bench/results/tree/part-compose-web.json
@@ -1,0 +1,96 @@
+{
+  "meta": {
+    "date": "2026-07-07T19:25:12.945Z",
+    "chromium": "149.0.7827.55",
+    "warmup": 1,
+    "samples": 5,
+    "totalNodes": 1555,
+    "cpuThrottle": null
+  },
+  "treeBenchmarks": [
+    {
+      "id": "t1_createTree",
+      "label": "create tree (1555 nodes)"
+    },
+    {
+      "id": "t2_updateLeaves",
+      "label": "update every 10th leaf"
+    },
+    {
+      "id": "t3_reverseTop",
+      "label": "reverse top-level subtrees"
+    },
+    {
+      "id": "t4_noopRender",
+      "label": "no-op re-render (data unchanged)"
+    }
+  ],
+  "tree": {
+    "compose-web": {
+      "t1_createTree": {
+        "samples": [
+          53.78,
+          57.72,
+          46.1,
+          47.13,
+          50.26
+        ],
+        "median": 50.26,
+        "mean": 51,
+        "stddev": 4.3,
+        "min": 46.1,
+        "max": 57.72,
+        "gcMedianMs": 23.89,
+        "pageErrors": 0
+      },
+      "t2_updateLeaves": {
+        "samples": [
+          13.34,
+          13.75,
+          12.73,
+          12.52,
+          12.31
+        ],
+        "median": 12.73,
+        "mean": 12.93,
+        "stddev": 0.54,
+        "min": 12.31,
+        "max": 13.75,
+        "gcMedianMs": 0,
+        "pageErrors": 0
+      },
+      "t3_reverseTop": {
+        "samples": [
+          16.47,
+          16.12,
+          15.79,
+          16.23,
+          14.78
+        ],
+        "median": 16.12,
+        "mean": 15.88,
+        "stddev": 0.59,
+        "min": 14.78,
+        "max": 16.47,
+        "gcMedianMs": 0,
+        "pageErrors": 0
+      },
+      "t4_noopRender": {
+        "samples": [
+          8.38,
+          8.65,
+          5.26,
+          7.86,
+          7.9
+        ],
+        "median": 7.9,
+        "mean": 7.61,
+        "stddev": 1.21,
+        "min": 5.26,
+        "max": 8.65,
+        "gcMedianMs": 0,
+        "pageErrors": 0
+      }
+    }
+  }
+}

--- a/project.yaml
+++ b/project.yaml
@@ -16,6 +16,7 @@ modules:
   - ./samples/annotated
   - ./samples/annotated-js
   - ./samples/browser-bench
+  - ./samples/browser-bench-compose
   - ./samples/browser-counter
   - ./samples/browser-tests
   - ./samples/browser-todo

--- a/samples/browser-bench-compose/module.yaml
+++ b/samples/browser-bench-compose/module.yaml
@@ -1,0 +1,15 @@
+product: js/app
+
+settings:
+  kotlin:
+    version: 2.4.0
+    languageVersion: 2.4
+    apiVersion: 2.4
+  compose:
+    enabled: true
+    version: 1.11.1
+
+dependencies:
+  - org.jetbrains.compose.html:html-core:1.11.1
+
+description: "js-framework-benchmark style keyed table app using Compose HTML (JetBrains Compose Multiplatform for Web), for performance comparison against Kinetica."

--- a/samples/browser-bench-compose/src/main.kt
+++ b/samples/browser-bench-compose/src/main.kt
@@ -1,0 +1,264 @@
+package app.browser.bench.compose
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.Composition
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.key
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import kotlinx.browser.window
+import org.jetbrains.compose.web.dom.A
+import org.jetbrains.compose.web.dom.Button
+import org.jetbrains.compose.web.dom.Div
+import org.jetbrains.compose.web.dom.H1
+import org.jetbrains.compose.web.dom.Span
+import org.jetbrains.compose.web.dom.Table
+import org.jetbrains.compose.web.dom.Tbody
+import org.jetbrains.compose.web.dom.Td
+import org.jetbrains.compose.web.dom.Text
+import org.jetbrains.compose.web.dom.Tr
+import org.jetbrains.compose.web.renderComposable
+
+data class RowData(val id: Int, val label: String)
+
+private val adjectives = listOf(
+    "pretty", "large", "big", "small", "tall", "short", "long", "handsome", "plain",
+    "quaint", "clean", "elegant", "easy", "angry", "crazy", "helpful", "mushy", "odd",
+    "unsightly", "adorable", "important", "inexpensive", "cheap", "expensive", "fancy",
+)
+private val colours = listOf(
+    "red", "yellow", "blue", "green", "pink", "brown", "purple", "brown", "white", "black", "orange",
+)
+private val nouns = listOf(
+    "table", "chair", "house", "bbq", "desk", "car", "pony", "cookie", "sandwich", "burger",
+    "pizza", "mouse", "keyboard",
+)
+
+private var nextId = 1
+
+private fun randomIndex(max: Int): Int =
+    js("Math.round(Math.random() * 1000) % max").unsafeCast<Int>()
+
+private fun buildData(count: Int): List<RowData> {
+    val adjectiveCount = adjectives.size
+    val colourCount = colours.size
+    val nounCount = nouns.size
+    return List(count) {
+        RowData(
+            id = nextId++,
+            label = "${adjectives[randomIndex(adjectiveCount)]} " +
+                "${colours[randomIndex(colourCount)]} " +
+                nouns[randomIndex(nounCount)],
+        )
+    }
+}
+
+private var animTick = 0
+
+@Composable
+private fun ToolbarButton(tag: String, label: String, handleClick: () -> Unit) {
+    Button(attrs = {
+        id(tag)
+        onClick { handleClick() }
+    }) {
+        Text(label)
+    }
+}
+
+// Its own composable function (not inlined into the table's for-loop) with only stable
+// parameters (Int/String/Boolean + remember-stable callbacks) so Compose can skip
+// recomposing rows whose id/label/selected haven't changed — the same reason the React
+// and Preact implementations wrap their row in memo() with useCallback handlers.
+@Composable
+private fun RowItem(id: Int, label: String, selected: Boolean, onSelect: (Int) -> Unit, onRemove: (Int) -> Unit) {
+    Tr(attrs = {
+        if (selected) classes("danger")
+        attr("data-id", id.toString())
+    }) {
+        Td(attrs = { classes("col-id") }) { Text(id.toString()) }
+        Td(attrs = { classes("col-label") }) {
+            A(attrs = {
+                classes("lbl")
+                onClick { onSelect(id) }
+            }) { Text(label) }
+        }
+        Td(attrs = { classes("col-remove") }) {
+            A(attrs = {
+                classes("remove")
+                onClick { onRemove(id) }
+            }) {
+                Span(attrs = {
+                    classes("remove-icon")
+                    attr("aria-hidden", "true")
+                }) {}
+            }
+        }
+        Td(attrs = { classes("col-rest") }) {}
+    }
+}
+
+@Composable
+fun BenchApp() {
+    var rows by remember { mutableStateOf(emptyList<RowData>()) }
+    var selectedId by remember { mutableStateOf(0) }
+    var animating by remember { mutableStateOf(false) }
+    // remember (no keys) creates each callback exactly once so RowItem's parameters stay
+    // referentially stable across recompositions — required for the skip above to trigger.
+    val onSelect = remember { { id: Int -> selectedId = id } }
+    val onRemove = remember { { id: Int -> rows = rows.filterNot { it.id == id } } }
+
+    // Drives the sustained-update ("animate") loop via a plain rAF chain — Compose's
+    // snapshot system schedules recomposition on any state write, from any callback,
+    // so no explicit "request render" call is needed (unlike Kinetica's event-only model).
+    DisposableEffect(animating) {
+        if (!animating) return@DisposableEffect onDispose {}
+        var rafId = 0
+        fun frame(timestamp: Double) {
+            animTick++
+            rows = rows.mapIndexed { index, row ->
+                if (index % 10 == 0) {
+                    row.copy(label = row.label.substringBefore(" !") + " !$animTick")
+                } else {
+                    row
+                }
+            }
+            rafId = window.requestAnimationFrame(::frame)
+        }
+        rafId = window.requestAnimationFrame(::frame)
+        onDispose { window.cancelAnimationFrame(rafId) }
+    }
+
+    Div {
+        Div(attrs = { classes("jumbotron") }) {
+            H1 { Text("Compose HTML (keyed)") }
+            Div(attrs = { classes("toolbar") }) {
+                ToolbarButton("run", "Create 1,000 rows") { rows = buildData(1_000); selectedId = 0 }
+                ToolbarButton("runlots", "Create 10,000 rows") { rows = buildData(10_000); selectedId = 0 }
+                ToolbarButton("add", "Append 1,000 rows") { rows = rows + buildData(1_000) }
+                ToolbarButton("update", "Update every 10th row") {
+                    rows = rows.mapIndexed { index, row ->
+                        if (index % 10 == 0) row.copy(label = row.label + " !!!") else row
+                    }
+                }
+                ToolbarButton("clear", "Clear") { rows = emptyList(); selectedId = 0 }
+                ToolbarButton("swaprows", "Swap Rows") {
+                    if (rows.size > 998) {
+                        val next = rows.toMutableList()
+                        val tmp = next[1]
+                        next[1] = next[998]
+                        next[998] = tmp
+                        rows = next
+                    }
+                }
+                ToolbarButton("animate", "Animate") { animating = !animating }
+            }
+        }
+        Table(attrs = { classes("test-data") }) {
+            Tbody {
+                for (row in rows) {
+                    key(row.id) {
+                        RowItem(row.id, row.label, row.id == selectedId, onSelect, onRemove)
+                    }
+                }
+            }
+        }
+    }
+}
+
+// --- tree benchmark app (UIBench-style; served from the same page with ?app=tree) ---
+//
+// Contract shared with bench/frameworks/*/tree.* and samples/browser-bench: depth 4,
+// fanout 6 => 1555 nodes, 1296 leaves. "run" rebuilds the tree with fresh ids, "update"
+// re-labels every 10th leaf (preorder) with " !<tick>", "reverse" reverses the root's
+// children, "noop" bumps only the status counter so the tree re-renders with unchanged data.
+
+data class TreeNodeData(val id: Int, val label: String, val children: List<TreeNodeData>)
+
+private const val TREE_DEPTH = 4
+private const val TREE_FANOUT = 6
+
+private var treeNextId = 1
+
+private fun buildTree(depth: Int = TREE_DEPTH, fanout: Int = TREE_FANOUT): TreeNodeData {
+    val id = treeNextId++
+    return TreeNodeData(
+        id = id,
+        label = "node $id",
+        children = if (depth == 0) emptyList() else List(fanout) { buildTree(depth - 1, fanout) },
+    )
+}
+
+private fun updateTreeLeaves(node: TreeNodeData, tick: Int, counter: IntArray): TreeNodeData {
+    if (node.children.isEmpty()) {
+        val index = counter[0]++
+        return if (index % 10 == 0) {
+            node.copy(label = node.label.substringBefore(" !") + " !$tick")
+        } else {
+            node
+        }
+    }
+    return node.copy(children = node.children.map { updateTreeLeaves(it, tick, counter) })
+}
+
+@Composable
+private fun TreeNode(node: TreeNodeData, depth: Int) {
+    Div(attrs = {
+        classes("tree-node")
+        attr("data-id", node.id.toString())
+        attr("data-depth", depth.toString())
+    }) {
+        if (node.children.isEmpty()) {
+            Span(attrs = { classes("tree-leaf") }) { Text(node.label) }
+        } else {
+            Span(attrs = { classes("tree-label") }) { Text(node.label) }
+            for (child in node.children) {
+                key(child.id) { TreeNode(child, depth + 1) }
+            }
+        }
+    }
+}
+
+@Composable
+fun TreeApp() {
+    var tree by remember { mutableStateOf<TreeNodeData?>(null) }
+    var tick by remember { mutableStateOf(0) }
+
+    Div {
+        Div(attrs = { classes("jumbotron") }) {
+            H1 { Text("Compose HTML tree") }
+            Div(attrs = { classes("toolbar") }) {
+                ToolbarButton("run", "Create tree") { tree = buildTree() }
+                ToolbarButton("update", "Update leaves") {
+                    tick += 1
+                    tree?.let { tree = updateTreeLeaves(it, tick, intArrayOf(0)) }
+                }
+                ToolbarButton("reverse", "Reverse") {
+                    tree?.let { current -> tree = current.copy(children = current.children.reversed()) }
+                }
+                ToolbarButton("noop", "No-op render") { tick += 1 }
+                Span(attrs = { id("status") }) { Text(tick.toString()) }
+            }
+        }
+        Div(attrs = { classes("tree-root") }) {
+            tree?.let { TreeNode(it, depth = 0) }
+        }
+    }
+}
+
+fun main() {
+    val isTree = window.location.search.contains("tree")
+    var composition: Composition? = null
+    fun mountApp() {
+        composition = renderComposable(rootElementId = "main") {
+            if (isTree) TreeApp() else BenchApp()
+        }
+    }
+    mountApp()
+    window.asDynamic().__mount = { mountApp() }
+    window.asDynamic().__unmount = {
+        composition?.dispose()
+        composition = null
+    }
+}

--- a/samples/browser-bench-compose/web/index.html
+++ b/samples/browser-bench-compose/web/index.html
@@ -1,0 +1,29 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Compose HTML keyed benchmark</title>
+  <link rel="stylesheet" href="../../../bench/frameworks/shared/styles.css">
+  <script>
+    window.__mountMs = undefined;
+    (function () {
+      function check() {
+        if (document.querySelector("#run, [data-testid=run]")) {
+          window.__mountMs = performance.now();
+          return true;
+        }
+        return false;
+      }
+      if (!check()) {
+        var mo = new MutationObserver(function () { if (check()) mo.disconnect(); });
+        mo.observe(document.documentElement, { childList: true, subtree: true });
+      }
+    })();
+  </script>
+</head>
+<body>
+  <div id="main"></div>
+  <script type="module" src="../../../build/tasks/_browser-bench-compose_bundle/browser-bench-compose.bundle.mjs"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Adds JetBrains Compose Multiplatform's DOM library (`org.jetbrains.compose.html:html-core` 1.11.1) as a 7th framework in `bench/`: table + tree apps in `samples/browser-bench-compose`, built via `bench/build-compose.mjs`, registered in `frameworks.config.mjs`.
- Row items are extracted into their own memoizable `@Composable fn` (`RowItem`) so Compose can skip unaffected rows on partial updates — lands within ~2x of the field there. But its default `for()`+`key()` list reconciliation appears to re-walk/diff the whole list rather than doing a minimal-move patch: full-list rebuilds run ~11x slower, and medial swap/remove on large lists is catastrophic (**remove-10k: ~50s, 1,276x the fastest framework**) — exactly the accidental-O(n²) signal the 10k-row ops are designed to catch.
- Widens two Playwright/driver timeouts in `bench/driver/common.mjs` (trace settle 280ms→700ms, action timeout 30s→180s), applied globally so no other framework's recorded numbers change — they're dead time around the actual measurement, needed because Compose's GC pressure and the remove-10k op push past the old defaults.
- `bench/README.md` documents the new framework, the timeout-widening rationale, and a full results interpretation writeup.

## Test plan
- [x] `node run-all.mjs --frameworks=compose-web --samples=2 --warmup=0 --tree` — build, selectors, and all assertions pass end-to-end
- [x] Real benchmark run (`--samples=5 --warmup=1 --tree`) merged into `bench/results/{results,tree}.json`, report regenerated
- [x] Verified other frameworks' recorded durations are unaffected by the widened timeouts (dead time after the measured window, not part of it)

🤖 Generated with [Claude Code](https://claude.com/claude-code)