### PR TITLE
Add Game of Life browser demo

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,7 +55,7 @@ jobs:
       - name: Build JS modules
         run: |
           set -euo pipefail
-          for module in kinetica-browser browser-tests browser-counter browser-todo \
+          for module in kinetica-browser browser-tests browser-counter browser-game-of-life browser-todo \
                         browser-bench docs-client server-components-client; do
             echo "=== $module"
             ./kotlin build -m "$module"
@@ -63,6 +63,9 @@ jobs:
 
       - name: Browser-runtime JS tests
         run: node build/tasks/_kinetica-browser_linkJsTest/kinetica-browser_test.mjs
+
+      - name: Game of Life model tests
+        run: node build/tasks/_browser-game-of-life_linkJsTest/browser-game-of-life_test.mjs
 
       # Frame storage and the IR ordinal emission must behave identically on the JS
       # backend, so the runtime and test-kit suites run on Node too.

--- a/project.yaml
+++ b/project.yaml
@@ -18,6 +18,7 @@ modules:
   - ./samples/browser-bench
   - ./samples/browser-bench-compose
   - ./samples/browser-counter
+  - ./samples/browser-game-of-life
   - ./samples/browser-tests
   - ./samples/browser-todo
   - ./samples/server-components

--- a/samples/browser-game-of-life/README.md
+++ b/samples/browser-game-of-life/README.md
@@ -1,0 +1,18 @@
+# Game of Life browser demo
+
+Build the Kotlin/JS bundle from the repository root:
+
+```sh
+./kotlin build -m browser-game-of-life
+```
+
+Serve the repository root (the shared benchmark server is convenient):
+
+```sh
+node -e 'import("./bench/driver/server.mjs").then(m => m.startServer(process.cwd(), 4173))'
+```
+
+Open <http://127.0.0.1:4173/samples/browser-game-of-life/web/index.html>.
+
+The demo uses a finite 72 × 48 B3/S23 board and includes Glider, Lightweight
+Spaceship, Beacon, and Pulsar presets. Click any cell to edit the current field.

--- a/samples/browser-game-of-life/module.yaml
+++ b/samples/browser-game-of-life/module.yaml
@@ -1,0 +1,10 @@
+product: js/app
+
+apply:
+  - ../../common.module-template.yaml
+
+dependencies:
+  - ../../kinetica-browser
+  - ../../kinetica-runtime
+
+description: "Interactive Conway's Game of Life browser demo with standard presets."

--- a/samples/browser-game-of-life/src/LifeModel.kt
+++ b/samples/browser-game-of-life/src/LifeModel.kt
@@ -1,0 +1,178 @@
+package app.browser.gameoflife
+
+import kotlin.random.Random
+
+data class GridPoint(
+    val column: Int,
+    val row: Int,
+)
+
+data class LifeBoard(
+    val columns: Int,
+    val rows: Int,
+    val livingCells: Set<GridPoint> = emptySet(),
+    val generation: Long = 0,
+) {
+    init {
+        require(columns > 0) { "Board columns must be positive." }
+        require(rows > 0) { "Board rows must be positive." }
+        require(generation >= 0) { "Generation must not be negative." }
+        require(livingCells.all { it in this }) { "Every living cell must be inside the board." }
+    }
+
+    val population: Int
+        get() = livingCells.size
+
+    operator fun contains(point: GridPoint): Boolean =
+        point.column in 0 until columns && point.row in 0 until rows
+
+    operator fun get(column: Int, row: Int): Boolean =
+        GridPoint(column, row) in livingCells
+
+    fun toggle(point: GridPoint): LifeBoard {
+        require(point in this) { "Cannot toggle a cell outside the board: $point" }
+        val nextCells = livingCells.toMutableSet()
+        if (!nextCells.add(point)) {
+            nextCells.remove(point)
+        }
+        return copy(livingCells = nextCells)
+    }
+
+    fun clear(): LifeBoard =
+        copy(livingCells = emptySet(), generation = 0)
+
+    fun randomized(
+        density: Double = 0.24,
+        random: Random = Random.Default,
+    ): LifeBoard {
+        require(density in 0.0..1.0) { "Density must be between 0 and 1." }
+        val nextCells = buildSet {
+            for (row in 0 until rows) {
+                for (column in 0 until columns) {
+                    if (random.nextDouble() < density) {
+                        add(GridPoint(column, row))
+                    }
+                }
+            }
+        }
+        return copy(livingCells = nextCells, generation = 0)
+    }
+
+    fun load(preset: LifePreset): LifeBoard {
+        require(preset.columns <= columns && preset.rows <= rows) {
+            "${preset.displayName} (${preset.columns}x${preset.rows}) does not fit on a ${columns}x$rows board."
+        }
+        val columnOffset = (columns - preset.columns) / 2
+        val rowOffset = (rows - preset.rows) / 2
+        return copy(
+            livingCells = preset.cells.mapTo(linkedSetOf()) { point ->
+                GridPoint(point.column + columnOffset, point.row + rowOffset)
+            },
+            generation = 0,
+        )
+    }
+
+    fun step(): LifeBoard {
+        val neighborCounts = HashMap<GridPoint, Int>()
+        for (cell in livingCells) {
+            for (rowDelta in -1..1) {
+                for (columnDelta in -1..1) {
+                    if (columnDelta == 0 && rowDelta == 0) continue
+                    val neighbor = GridPoint(
+                        column = cell.column + columnDelta,
+                        row = cell.row + rowDelta,
+                    )
+                    if (neighbor in this) {
+                        neighborCounts[neighbor] = (neighborCounts[neighbor] ?: 0) + 1
+                    }
+                }
+            }
+        }
+
+        val nextCells = buildSet {
+            for ((point, neighbors) in neighborCounts) {
+                if (neighbors == 3 || neighbors == 2 && point in livingCells) {
+                    add(point)
+                }
+            }
+        }
+        return copy(livingCells = nextCells, generation = generation + 1)
+    }
+}
+
+enum class LifePreset(
+    val displayName: String,
+    val category: String,
+    val description: String,
+    patternRows: List<String>,
+) {
+    GLIDER(
+        displayName = "Glider",
+        category = "Spaceship · period 4",
+        description = "The smallest pattern that travels across the field.",
+        patternRows = listOf(
+            ".O.",
+            "..O",
+            "OOO",
+        ),
+    ),
+    LIGHTWEIGHT_SPACESHIP(
+        displayName = "Lightweight spaceship",
+        category = "Spaceship · period 4",
+        description = "A nine-cell craft moving horizontally at half light speed.",
+        patternRows = listOf(
+            ".O..O",
+            "O....",
+            "O...O",
+            "OOOO.",
+        ),
+    ),
+    BEACON(
+        displayName = "Beacon",
+        category = "Oscillator · period 2",
+        description = "Two blocks blink between connected and separated phases.",
+        patternRows = listOf(
+            "OO..",
+            "OO..",
+            "..OO",
+            "..OO",
+        ),
+    ),
+    PULSAR(
+        displayName = "Pulsar",
+        category = "Oscillator · period 3",
+        description = "A symmetric 48-cell classic with a dramatic three-step pulse.",
+        patternRows = listOf(
+            "..OOO...OOO..",
+            ".............",
+            "O....O.O....O",
+            "O....O.O....O",
+            "O....O.O....O",
+            "..OOO...OOO..",
+            ".............",
+            "..OOO...OOO..",
+            "O....O.O....O",
+            "O....O.O....O",
+            "O....O.O....O",
+            ".............",
+            "..OOO...OOO..",
+        ),
+    ),
+    ;
+
+    val id: String = name.lowercase().replace('_', '-')
+    val rows: Int = patternRows.size
+    val columns: Int = patternRows.firstOrNull()?.length ?: 0
+    val cells: Set<GridPoint> = buildSet {
+        require(patternRows.isNotEmpty()) { "$displayName must contain at least one row." }
+        patternRows.forEachIndexed { row, patternRow ->
+            require(patternRow.length == columns) { "$displayName must be rectangular." }
+            patternRow.forEachIndexed { column, value ->
+                require(value == '.' || value == 'O') { "$displayName contains an unsupported cell marker: $value" }
+                if (value == 'O') {
+                    add(GridPoint(column, row))
+                }
+            }
+        }
+    }
+}

--- a/samples/browser-game-of-life/src/main.kt
+++ b/samples/browser-game-of-life/src/main.kt
@@ -1,0 +1,363 @@
+package app.browser.gameoflife
+
+import io.heapy.kinetica.ComponentScope
+import io.heapy.kinetica.KineticaRuntime
+import io.heapy.kinetica.Role
+import io.heapy.kinetica.Semantics
+import io.heapy.kinetica.UiComponent
+import io.heapy.kinetica.browser.BrowserKineticaApp
+import io.heapy.kinetica.browser.mountKineticaApp
+import io.heapy.kinetica.button
+import io.heapy.kinetica.derived
+import io.heapy.kinetica.each
+import io.heapy.kinetica.event
+import io.heapy.kinetica.host
+import io.heapy.kinetica.hostEvent
+import io.heapy.kinetica.propsOf
+import io.heapy.kinetica.state
+import io.heapy.kinetica.text
+import io.heapy.kinetica.watch
+import kotlinx.coroutines.delay
+
+private const val BoardColumns = 72
+private const val BoardRows = 48
+
+private enum class SimulationSpeed(
+    val label: String,
+    val delayMillis: Long,
+) {
+    SLOW("Slow", 420),
+    NORMAL("Normal", 180),
+    FAST("Fast", 80),
+}
+
+private data class CellView(
+    val index: Int,
+    val point: GridPoint,
+    val alive: Boolean,
+)
+
+@UiComponent
+fun ComponentScope.GameOfLifeApp(requestRender: () -> Unit = {}) {
+    var board by state { LifeBoard(BoardColumns, BoardRows).load(LifePreset.PULSAR) }
+    var running by state { false }
+    var speed by state { SimulationSpeed.NORMAL }
+    var selectedPreset: LifePreset? by state { LifePreset.PULSAR }
+
+    val population by derived { board.population }
+    val cells by derived {
+        List(BoardColumns * BoardRows) { index ->
+            val point = GridPoint(
+                column = index % BoardColumns,
+                row = index / BoardColumns,
+            )
+            CellView(index = index, point = point, alive = board[point.column, point.row])
+        }
+    }
+
+    watch(source = { running to speed.delayMillis }) { (isRunning, tickDelay) ->
+        if (isRunning) {
+            while (true) {
+                delay(tickDelay)
+                val next = board.step()
+                board = next
+                if (next.population == 0) {
+                    running = false
+                }
+                requestRender()
+                if (next.population == 0) break
+            }
+        }
+    }
+
+    val toggleRunning = event {
+        if (population > 0) {
+            running = !running
+        }
+    }
+    val stepOnce = event {
+        running = false
+        board = board.step()
+    }
+    val randomize = event {
+        running = false
+        selectedPreset = null
+        board = board.randomized()
+    }
+    val clear = event {
+        running = false
+        selectedPreset = null
+        board = board.clear()
+    }
+
+    host("div", props = propsOf("class", "life-app"), semantics = Semantics(testTag = "game-of-life-app")) {
+        host("header", props = propsOf("class", "hero")) {
+            host("div", props = propsOf("class", "brand-line")) {
+                host("span", props = propsOf("class", "brand-mark", "aria-hidden", "true")) {
+                    text("K", semantics = null)
+                }
+                host("span", props = propsOf("class", "eyebrow")) {
+                    text("Kinetica playground", semantics = null)
+                }
+                host("span", props = propsOf("class", "rule-chip")) {
+                    text("B3 / S23", semantics = null)
+                }
+            }
+            host("div", props = propsOf("class", "hero-copy")) {
+                host("h1") { text("Conway’s Game of Life", semantics = null) }
+                host("p") {
+                    text(
+                        "Seed a world, set it in motion, and watch four simple rules create complex behavior.",
+                        semantics = null,
+                    )
+                }
+            }
+        }
+
+        host("div", props = propsOf("class", "workspace")) {
+            host("aside", props = propsOf("class", "preset-panel", "aria-label", "Pattern presets")) {
+                host("div", props = propsOf("class", "section-heading")) {
+                    host("span", props = propsOf("class", "section-kicker")) {
+                        text("Start here", semantics = null)
+                    }
+                    host("h2") { text("Classic patterns", semantics = null) }
+                    host("p") {
+                        text("Load a known form, then run it or reshape it cell by cell.", semantics = null)
+                    }
+                }
+
+                host("div", props = propsOf("class", "preset-list")) {
+                    each(LifePreset.entries, key = { it.id }) { preset ->
+                        val selected = preset == selectedPreset
+                        host(
+                            "div",
+                            props = propsOf("class", if (selected) "preset-option is-selected" else "preset-option"),
+                            key = preset.id,
+                        ) {
+                            button(
+                                onClick = event {
+                                    running = false
+                                    selectedPreset = preset
+                                    board = board.load(preset)
+                                    centerBoardViewport()
+                                },
+                                semantics = Semantics(
+                                    role = Role.Button,
+                                    label = "Load ${preset.displayName}",
+                                    stateDescription = if (selected) "Selected preset" else null,
+                                    testTag = "preset-${preset.id}",
+                                    focusable = true,
+                                ),
+                            ) {
+                                host("span", props = propsOf("class", "preset-title")) {
+                                    text(preset.displayName, semantics = null)
+                                    host("span", props = propsOf("class", "preset-size")) {
+                                        text("${preset.columns} × ${preset.rows}", semantics = null)
+                                    }
+                                }
+                                host("span", props = propsOf("class", "preset-category")) {
+                                    text(preset.category, semantics = null)
+                                }
+                                host("span", props = propsOf("class", "preset-description")) {
+                                    text(preset.description, semantics = null)
+                                }
+                            }
+                        }
+                    }
+                }
+
+                host("div", props = propsOf("class", "tip-card")) {
+                    host("span", props = propsOf("class", "tip-icon", "aria-hidden", "true")) {
+                        text("✦", semantics = null)
+                    }
+                    host("p") {
+                        text("Tip: select any square on the board to toggle it. Editing pauses the simulation.", semantics = null)
+                    }
+                }
+            }
+
+            host("main", props = propsOf("class", "simulation-panel")) {
+                host("div", props = propsOf("class", "control-bar")) {
+                    host("div", props = propsOf("class", "primary-actions")) {
+                        button(
+                            onClick = toggleRunning,
+                            enabled = population > 0,
+                            semantics = Semantics(
+                                role = Role.Button,
+                                label = if (running) "Pause simulation" else "Run simulation",
+                                testTag = "toggle-running",
+                                focusable = true,
+                            ),
+                        ) {
+                            host("span", props = propsOf("aria-hidden", "true", "class", "button-icon")) {
+                                text(if (running) "Ⅱ" else "▶", semantics = null)
+                            }
+                            text(if (running) "Pause" else "Run", semantics = null)
+                        }
+                        button(
+                            onClick = stepOnce,
+                            semantics = Semantics(
+                                role = Role.Button,
+                                label = "Advance one generation",
+                                testTag = "step",
+                                focusable = true,
+                            ),
+                        ) {
+                            host("span", props = propsOf("aria-hidden", "true", "class", "button-icon")) {
+                                text("↦", semantics = null)
+                            }
+                            text("Step", semantics = null)
+                        }
+                    }
+
+                    host("div", props = propsOf("class", "secondary-actions")) {
+                        button(
+                            onClick = randomize,
+                            semantics = Semantics(role = Role.Button, testTag = "randomize", focusable = true),
+                        ) {
+                            text("Randomize", semantics = null)
+                        }
+                        button(
+                            onClick = clear,
+                            enabled = population > 0,
+                            semantics = Semantics(role = Role.Button, testTag = "clear", focusable = true),
+                        ) {
+                            text("Clear", semantics = null)
+                        }
+                    }
+
+                    host("div", props = propsOf("class", "speed-control", "aria-label", "Simulation speed")) {
+                        host("span", props = propsOf("class", "speed-label")) { text("Speed", semantics = null) }
+                        host("div", props = propsOf("class", "speed-options")) {
+                            each(SimulationSpeed.entries, key = { it.name }) { option ->
+                                button(
+                                    onClick = event { speed = option },
+                                    enabled = speed != option,
+                                    semantics = Semantics(
+                                        role = Role.Button,
+                                        label = "${option.label} speed",
+                                        stateDescription = if (speed == option) "Selected speed" else null,
+                                        testTag = "speed-${option.name.lowercase()}",
+                                        focusable = true,
+                                    ),
+                                ) {
+                                    text(option.label, semantics = null)
+                                }
+                            }
+                        }
+                    }
+                }
+
+                host("div", props = propsOf("class", "status-strip", "aria-live", "polite")) {
+                    host("div", props = propsOf("class", "status-item")) {
+                        host("span", props = propsOf("class", "status-label")) { text("Generation", semantics = null) }
+                        host("strong", semantics = Semantics(testTag = "generation-value")) {
+                            text(board.generation.toString(), semantics = null)
+                        }
+                    }
+                    host("div", props = propsOf("class", "status-item")) {
+                        host("span", props = propsOf("class", "status-label")) { text("Population", semantics = null) }
+                        host("strong", semantics = Semantics(testTag = "population-value")) {
+                            text(population.toString(), semantics = null)
+                        }
+                    }
+                    host("div", props = propsOf("class", "status-item pattern-status")) {
+                        host("span", props = propsOf("class", "status-label")) { text("Pattern", semantics = null) }
+                        host("strong") { text(selectedPreset?.displayName ?: "Custom field", semantics = null) }
+                    }
+                    host("div", props = propsOf("class", "run-state")) {
+                        host(
+                            "span",
+                            props = propsOf("class", if (running) "state-dot is-running" else "state-dot"),
+                            semantics = Semantics(testTag = "run-state-indicator"),
+                        )
+                        text(if (running) "Evolving" else "Paused", semantics = null)
+                    }
+                }
+
+                host("div", props = propsOf("class", "board-frame")) {
+                    host("div", props = propsOf("class", "board-chrome")) {
+                        host("div", props = propsOf("class", "board-caption")) {
+                            host("span") { text("$BoardColumns × $BoardRows universe", semantics = null) }
+                            host("span", props = propsOf("class", "coordinate-hint")) {
+                                text("Finite boundary · outside cells stay dead", semantics = null)
+                            }
+                        }
+                        host("div", props = propsOf("class", "board-scroll")) {
+                            host(
+                                "div",
+                                props = propsOf(
+                                    "class", "life-grid",
+                                    "role", "grid",
+                                    "aria-label", "Editable Game of Life grid",
+                                ),
+                                semantics = Semantics(testTag = "life-grid"),
+                            ) {
+                                each(cells, key = { it.index }) { cell ->
+                                    val click = hostEvent(onEvent = event {
+                                        running = false
+                                        selectedPreset = null
+                                        board = board.toggle(cell.point)
+                                    })
+                                    host(
+                                        "button",
+                                        props = propsOf(
+                                            "type" to "button",
+                                            "class" to if (cell.alive) "life-cell is-alive" else "life-cell",
+                                            "aria-pressed" to cell.alive.toString(),
+                                            "event:onClick" to click,
+                                        ),
+                                        semantics = Semantics(
+                                            role = Role.Button,
+                                            label = "Column ${cell.point.column + 1}, row ${cell.point.row + 1}",
+                                            stateDescription = if (cell.alive) "Alive" else "Dead",
+                                            testTag = "cell-${cell.point.column}-${cell.point.row}",
+                                            focusable = true,
+                                        ),
+                                        key = cell.index,
+                                    )
+                                }
+                            }
+                        }
+                    }
+                }
+
+                host("div", props = propsOf("class", "rule-legend")) {
+                    host("div") {
+                        host("span", props = propsOf("class", "legend-number")) { text("3", semantics = null) }
+                        host("p") { text("A dead cell with three neighbors is born.", semantics = null) }
+                    }
+                    host("div") {
+                        host("span", props = propsOf("class", "legend-number")) { text("2–3", semantics = null) }
+                        host("p") { text("A live cell with two or three neighbors survives.", semantics = null) }
+                    }
+                    host("div") {
+                        host("span", props = propsOf("class", "legend-number muted-number")) { text("0–1 / 4+", semantics = null) }
+                        host("p") { text("Every other live cell fades from the field.", semantics = null) }
+                    }
+                }
+            }
+        }
+    }
+}
+
+fun main() {
+    var app: BrowserKineticaApp? = null
+    app = mountKineticaApp("#app", runtime = KineticaRuntime(debug = false)) {
+        GameOfLifeApp { app?.render() }
+    }
+    centerBoardViewport()
+}
+
+private fun centerBoardViewport() {
+    js(
+        """
+        requestAnimationFrame(function () {
+            var viewport = document.querySelector('.board-scroll');
+            if (viewport) {
+                viewport.scrollLeft = (viewport.scrollWidth - viewport.clientWidth) / 2;
+            }
+        });
+        """,
+    )
+}

--- a/samples/browser-game-of-life/test/LifeModelTest.kt
+++ b/samples/browser-game-of-life/test/LifeModelTest.kt
@@ -1,0 +1,117 @@
+package app.browser.gameoflife
+
+import kotlin.random.Random
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class LifeModelTest {
+    @Test
+    fun blockIsStableAndBlinkerHasPeriodTwo() {
+        val blockCells = points(4 to 4, 5 to 4, 4 to 5, 5 to 5)
+        val block = LifeBoard(columns = 10, rows = 10, livingCells = blockCells)
+        assertEquals(blockCells, block.step().livingCells)
+        assertEquals(1, block.step().generation)
+
+        val horizontal = LifeBoard(
+            columns = 7,
+            rows = 7,
+            livingCells = points(2 to 3, 3 to 3, 4 to 3),
+        )
+        val vertical = points(3 to 2, 3 to 3, 3 to 4)
+        assertEquals(vertical, horizontal.step().livingCells)
+        assertEquals(horizontal.livingCells, horizontal.step().step().livingCells)
+    }
+
+    @Test
+    fun spaceshipsTranslateAfterFourGenerations() {
+        val glider = LifeBoard(24, 20).load(LifePreset.GLIDER)
+        assertEquals(
+            glider.livingCells.shifted(columnDelta = 1, rowDelta = 1),
+            glider.after(4).livingCells,
+        )
+
+        val lightweightSpaceship = LifeBoard(24, 20).load(LifePreset.LIGHTWEIGHT_SPACESHIP)
+        assertEquals(
+            lightweightSpaceship.livingCells.shifted(columnDelta = -2, rowDelta = 0),
+            lightweightSpaceship.after(4).livingCells,
+        )
+    }
+
+    @Test
+    fun beaconAndPulsarReturnToTheirStartingPhases() {
+        val beacon = LifeBoard(24, 20).load(LifePreset.BEACON)
+        assertEquals(beacon.livingCells, beacon.after(2).livingCells)
+
+        val pulsar = LifeBoard(24, 20).load(LifePreset.PULSAR)
+        assertEquals(pulsar.livingCells, pulsar.after(3).livingCells)
+    }
+
+    @Test
+    fun finiteBoundaryDoesNotWrapCellsAroundTheBoard() {
+        val edgeBlinker = LifeBoard(
+            columns = 4,
+            rows = 4,
+            livingCells = points(0 to 0, 0 to 1, 0 to 2),
+        )
+
+        assertEquals(points(0 to 1, 1 to 1), edgeBlinker.step().livingCells)
+    }
+
+    @Test
+    fun presetsCenterAndBoardEditingStaysImmutable() {
+        val original = LifeBoard(columns = 11, rows = 9, generation = 12)
+        val loaded = original.load(LifePreset.GLIDER)
+        assertEquals(0, loaded.generation)
+        assertEquals(points(5 to 3, 6 to 4, 4 to 5, 5 to 5, 6 to 5), loaded.livingCells)
+
+        val toggled = loaded.toggle(GridPoint(0, 0))
+        assertFalse(GridPoint(0, 0) in loaded.livingCells)
+        assertTrue(GridPoint(0, 0) in toggled.livingCells)
+        assertEquals(loaded.generation, toggled.generation)
+        assertEquals(LifeBoard(11, 9), toggled.clear())
+    }
+
+    @Test
+    fun presetsAndRandomBoardsHaveExpectedPopulations() {
+        assertEquals(
+            mapOf(
+                LifePreset.GLIDER to 5,
+                LifePreset.LIGHTWEIGHT_SPACESHIP to 9,
+                LifePreset.BEACON to 8,
+                LifePreset.PULSAR to 48,
+            ),
+            LifePreset.entries.associateWith { it.cells.size },
+        )
+
+        val board = LifeBoard(5, 4, generation = 9)
+        assertEquals(0, board.randomized(density = 0.0, random = Random(7)).population)
+        val full = board.randomized(density = 1.0, random = Random(7))
+        assertEquals(20, full.population)
+        assertEquals(0, full.generation)
+    }
+
+    @Test
+    fun invalidBoardsAndOperationsAreRejected() {
+        assertFailsWith<IllegalArgumentException> { LifeBoard(columns = 0, rows = 3) }
+        assertFailsWith<IllegalArgumentException> {
+            LifeBoard(columns = 3, rows = 3, livingCells = points(3 to 0))
+        }
+        assertFailsWith<IllegalArgumentException> { LifeBoard(2, 2).load(LifePreset.GLIDER) }
+        assertFailsWith<IllegalArgumentException> { LifeBoard(3, 3).toggle(GridPoint(-1, 0)) }
+        assertFailsWith<IllegalArgumentException> { LifeBoard(3, 3).randomized(density = 1.1) }
+    }
+}
+
+private fun points(vararg coordinates: Pair<Int, Int>): Set<GridPoint> =
+    coordinates.mapTo(linkedSetOf()) { (column, row) -> GridPoint(column, row) }
+
+private fun Set<GridPoint>.shifted(columnDelta: Int, rowDelta: Int): Set<GridPoint> =
+    mapTo(linkedSetOf()) { point ->
+        GridPoint(point.column + columnDelta, point.row + rowDelta)
+    }
+
+private fun LifeBoard.after(generations: Int): LifeBoard =
+    (0 until generations).fold(this) { board, _ -> board.step() }

--- a/samples/browser-game-of-life/web/index.html
+++ b/samples/browser-game-of-life/web/index.html
@@ -1,0 +1,18 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta
+    name="description"
+    content="An interactive Conway's Game of Life demo built with the Kinetica Kotlin UI framework."
+  >
+  <title>Kinetica · Conway’s Game of Life</title>
+  <link rel="stylesheet" href="./styles.css">
+</head>
+<body>
+  <div id="app"></div>
+  <noscript>This demo needs JavaScript to evolve the universe.</noscript>
+  <script type="module" src="../../../build/tasks/_browser-game-of-life_linkJs/browser-game-of-life.mjs"></script>
+</body>
+</html>

--- a/samples/browser-game-of-life/web/styles.css
+++ b/samples/browser-game-of-life/web/styles.css
@@ -1,0 +1,735 @@
+:root {
+  color-scheme: dark;
+  font-family:
+    Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI",
+    sans-serif;
+  font-synthesis: none;
+  background: #070a12;
+  color: #f4f7ff;
+  --canvas: #070a12;
+  --surface: #101624;
+  --surface-raised: #151d2e;
+  --surface-soft: #1a2335;
+  --border: #28344a;
+  --border-bright: #3d4f6d;
+  --text: #f4f7ff;
+  --muted: #96a4bb;
+  --muted-bright: #bac5d7;
+  --mint: #7cf7c8;
+  --mint-deep: #2ccf9b;
+  --blue: #87a8ff;
+  --amber: #ffc876;
+  --shadow: 0 30px 90px rgb(0 0 0 / 34%);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html {
+  min-width: 320px;
+  min-height: 100%;
+  background: var(--canvas);
+}
+
+body {
+  min-height: 100vh;
+  margin: 0;
+  background:
+    radial-gradient(circle at 8% 4%, rgb(70 103 181 / 19%), transparent 34rem),
+    radial-gradient(circle at 94% 15%, rgb(44 207 155 / 10%), transparent 28rem),
+    linear-gradient(180deg, #0a0e18 0%, #070a12 62%, #090d16 100%);
+}
+
+body::before {
+  position: fixed;
+  z-index: -1;
+  inset: 0;
+  background-image:
+    linear-gradient(rgb(255 255 255 / 1.8%) 1px, transparent 1px),
+    linear-gradient(90deg, rgb(255 255 255 / 1.8%) 1px, transparent 1px);
+  background-size: 44px 44px;
+  mask-image: linear-gradient(to bottom, black, transparent 78%);
+  content: "";
+  pointer-events: none;
+}
+
+button {
+  font: inherit;
+}
+
+button:focus-visible {
+  outline: 3px solid rgb(135 168 255 / 75%);
+  outline-offset: 3px;
+}
+
+noscript {
+  display: block;
+  padding: 2rem;
+  color: var(--muted-bright);
+  text-align: center;
+}
+
+.life-app {
+  width: min(1380px, 100%);
+  min-height: 100vh;
+  margin: 0 auto;
+  padding: 34px clamp(18px, 3vw, 48px) 48px;
+}
+
+.hero {
+  margin-bottom: 26px;
+  padding: 0 2px;
+}
+
+.brand-line {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin-bottom: 18px;
+}
+
+.brand-mark {
+  display: grid;
+  width: 30px;
+  height: 30px;
+  border: 1px solid rgb(124 247 200 / 48%);
+  border-radius: 9px;
+  background: linear-gradient(145deg, rgb(124 247 200 / 18%), rgb(135 168 255 / 12%));
+  color: var(--mint);
+  font-weight: 800;
+  font-size: 14px;
+  box-shadow: inset 0 1px rgb(255 255 255 / 10%), 0 8px 22px rgb(44 207 155 / 8%);
+  place-items: center;
+}
+
+.eyebrow,
+.section-kicker {
+  color: var(--muted-bright);
+  font-weight: 700;
+  font-size: 11px;
+  line-height: 1;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+}
+
+.rule-chip {
+  margin-left: auto;
+  padding: 7px 11px;
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  background: rgb(16 22 36 / 75%);
+  color: var(--mint);
+  font: 700 11px/1 ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  letter-spacing: 0.08em;
+}
+
+.hero-copy {
+  display: flex;
+  align-items: end;
+  justify-content: space-between;
+  gap: 30px;
+}
+
+.hero h1 {
+  margin: 0;
+  color: var(--text);
+  font-weight: 690;
+  font-size: clamp(36px, 5vw, 66px);
+  line-height: 0.98;
+  letter-spacing: -0.052em;
+}
+
+.hero-copy p {
+  width: min(420px, 100%);
+  margin: 0 0 4px;
+  color: var(--muted);
+  font-size: 14px;
+  line-height: 1.65;
+}
+
+.workspace {
+  display: grid;
+  grid-template-columns: 272px minmax(0, 1fr);
+  gap: 18px;
+  align-items: start;
+}
+
+.preset-panel,
+.simulation-panel {
+  border: 1px solid var(--border);
+  border-radius: 20px;
+  background: rgb(16 22 36 / 92%);
+  box-shadow: var(--shadow);
+  backdrop-filter: blur(18px);
+}
+
+.preset-panel {
+  position: sticky;
+  top: 18px;
+  overflow: hidden;
+  padding: 22px;
+}
+
+.section-heading {
+  padding: 2px 2px 18px;
+}
+
+.section-heading h2 {
+  margin: 8px 0 8px;
+  font-weight: 680;
+  font-size: 21px;
+  letter-spacing: -0.025em;
+}
+
+.section-heading p {
+  margin: 0;
+  color: var(--muted);
+  font-size: 12px;
+  line-height: 1.55;
+}
+
+.preset-list {
+  display: grid;
+  gap: 8px;
+}
+
+.preset-option {
+  position: relative;
+}
+
+.preset-option::before {
+  position: absolute;
+  z-index: 1;
+  top: 12px;
+  bottom: 12px;
+  left: 0;
+  width: 3px;
+  border-radius: 999px;
+  background: transparent;
+  content: "";
+  transition: background 160ms ease, box-shadow 160ms ease;
+}
+
+.preset-option.is-selected::before {
+  background: var(--mint);
+  box-shadow: 0 0 16px rgb(124 247 200 / 52%);
+}
+
+.preset-option > button {
+  display: flex;
+  width: 100%;
+  min-height: 96px;
+  flex-direction: column;
+  gap: 5px;
+  align-items: stretch;
+  padding: 13px 13px 12px 15px;
+  border: 1px solid transparent;
+  border-radius: 12px;
+  background: transparent;
+  color: var(--text);
+  cursor: pointer;
+  text-align: left;
+  transition: border-color 160ms ease, background 160ms ease, transform 160ms ease;
+}
+
+.preset-option > button:hover {
+  border-color: var(--border);
+  background: var(--surface-soft);
+  transform: translateX(2px);
+}
+
+.preset-option.is-selected > button {
+  border-color: rgb(124 247 200 / 18%);
+  background: linear-gradient(90deg, rgb(124 247 200 / 10%), rgb(124 247 200 / 2%));
+}
+
+.preset-title {
+  display: flex;
+  gap: 8px;
+  align-items: baseline;
+  justify-content: space-between;
+  font-weight: 700;
+  font-size: 13px;
+}
+
+.preset-size {
+  flex: 0 0 auto;
+  color: var(--muted);
+  font: 600 9px/1 ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+}
+
+.preset-category {
+  color: var(--mint);
+  font-weight: 700;
+  font-size: 9px;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
+.preset-description {
+  color: var(--muted);
+  font-size: 10px;
+  line-height: 1.45;
+}
+
+.tip-card {
+  display: flex;
+  gap: 10px;
+  align-items: flex-start;
+  margin-top: 18px;
+  padding: 13px;
+  border: 1px solid rgb(135 168 255 / 18%);
+  border-radius: 12px;
+  background: rgb(135 168 255 / 7%);
+}
+
+.tip-icon {
+  color: var(--blue);
+  line-height: 1.3;
+}
+
+.tip-card p {
+  margin: 0;
+  color: var(--muted-bright);
+  font-size: 10px;
+  line-height: 1.5;
+}
+
+.simulation-panel {
+  overflow: hidden;
+  min-width: 0;
+}
+
+.control-bar {
+  display: grid;
+  grid-template-columns: auto auto 1fr;
+  gap: 12px;
+  align-items: center;
+  padding: 16px 18px;
+  border-bottom: 1px solid var(--border);
+  background: rgb(21 29 46 / 70%);
+}
+
+.primary-actions,
+.secondary-actions,
+.speed-options {
+  display: flex;
+  gap: 7px;
+  align-items: center;
+}
+
+.control-bar button {
+  min-height: 36px;
+  padding: 0 13px;
+  border: 1px solid var(--border-bright);
+  border-radius: 9px;
+  background: var(--surface-soft);
+  color: var(--muted-bright);
+  font-weight: 680;
+  font-size: 11px;
+  cursor: pointer;
+  transition: border-color 150ms ease, background 150ms ease, color 150ms ease, transform 150ms ease;
+}
+
+.control-bar button:hover:not(:disabled) {
+  border-color: #5b7095;
+  background: #222e44;
+  color: var(--text);
+  transform: translateY(-1px);
+}
+
+.control-bar button:disabled {
+  cursor: not-allowed;
+  opacity: 0.38;
+}
+
+.primary-actions [data-testid="toggle-running"] {
+  min-width: 88px;
+  border-color: rgb(124 247 200 / 34%);
+  background: var(--mint);
+  color: #071811;
+  box-shadow: 0 8px 24px rgb(44 207 155 / 15%);
+}
+
+.primary-actions [data-testid="toggle-running"]:hover:not(:disabled) {
+  border-color: var(--mint);
+  background: #96fbd5;
+  color: #071811;
+}
+
+.button-icon {
+  display: inline-block;
+  min-width: 13px;
+  margin-right: 6px;
+  font-size: 10px;
+  text-align: center;
+}
+
+.speed-control {
+  display: flex;
+  gap: 9px;
+  align-items: center;
+  justify-self: end;
+}
+
+.speed-label {
+  color: var(--muted);
+  font-weight: 700;
+  font-size: 9px;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+.speed-options {
+  gap: 3px;
+  padding: 3px;
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  background: #0d1320;
+}
+
+.speed-options button {
+  min-height: 27px;
+  padding: 0 9px;
+  border: 0;
+  border-radius: 6px;
+  background: transparent;
+  font-size: 9px;
+}
+
+.speed-options button:disabled {
+  background: var(--surface-soft);
+  color: var(--mint);
+  cursor: default;
+  opacity: 1;
+}
+
+.status-strip {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(82px, auto)) minmax(120px, 1fr) auto;
+  gap: 0;
+  align-items: center;
+  min-height: 70px;
+  padding: 0 20px;
+  border-bottom: 1px solid var(--border);
+}
+
+.status-item {
+  display: grid;
+  gap: 3px;
+  padding-right: 26px;
+}
+
+.status-label {
+  color: var(--muted);
+  font-weight: 700;
+  font-size: 8px;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+.status-item strong {
+  font-weight: 690;
+  font-size: 15px;
+  letter-spacing: -0.015em;
+}
+
+.pattern-status strong {
+  overflow: hidden;
+  color: var(--muted-bright);
+  font-size: 12px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.run-state {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+  justify-self: end;
+  color: var(--muted-bright);
+  font-weight: 680;
+  font-size: 10px;
+}
+
+.state-dot {
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  background: #637087;
+  box-shadow: 0 0 0 4px rgb(99 112 135 / 10%);
+}
+
+.state-dot.is-running {
+  background: var(--mint);
+  box-shadow: 0 0 0 4px rgb(124 247 200 / 10%), 0 0 18px rgb(124 247 200 / 65%);
+  animation: breathe 1.2s ease-in-out infinite;
+}
+
+.board-frame {
+  padding: clamp(12px, 2.2vw, 24px);
+  background:
+    radial-gradient(circle at center, rgb(34 50 76 / 16%), transparent 68%),
+    #0b101b;
+}
+
+.board-chrome {
+  overflow: hidden;
+  border: 1px solid #2d3b53;
+  border-radius: 14px;
+  background: #080d17;
+  box-shadow: inset 0 1px rgb(255 255 255 / 4%), 0 20px 46px rgb(0 0 0 / 24%);
+}
+
+.board-caption {
+  display: flex;
+  min-height: 38px;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0 13px;
+  border-bottom: 1px solid #202b3e;
+  color: var(--muted-bright);
+  font: 650 9px/1 ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
+.coordinate-hint {
+  color: #687790;
+  font-weight: 560;
+  font-size: 8px;
+  letter-spacing: 0.03em;
+  text-transform: none;
+}
+
+.board-scroll {
+  overflow-x: auto;
+  padding: clamp(10px, 1.7vw, 18px);
+  scrollbar-color: #3d4f6d #0b101b;
+  scrollbar-width: thin;
+}
+
+.life-grid {
+  display: grid;
+  width: 100%;
+  min-width: 1080px;
+  grid-template-columns: repeat(72, minmax(0, 1fr));
+  gap: 1px;
+  padding: 2px;
+  border-radius: 5px;
+  background: #0e1625;
+}
+
+.life-cell {
+  position: relative;
+  width: 100%;
+  min-width: 0;
+  padding: 0;
+  border: 0;
+  border-radius: 2px;
+  aspect-ratio: 1;
+  background: #151e2e;
+  box-shadow: inset 0 0 0 1px rgb(255 255 255 / 1.6%);
+  cursor: crosshair;
+  transition: background 90ms ease, box-shadow 90ms ease, transform 90ms ease;
+}
+
+.life-cell:hover {
+  z-index: 1;
+  background: #25344c;
+  box-shadow: inset 0 0 0 1px rgb(135 168 255 / 32%), 0 0 0 1px rgb(135 168 255 / 18%);
+  transform: scale(1.16);
+}
+
+.life-cell.is-alive {
+  background: linear-gradient(145deg, #a6ffdf 4%, var(--mint) 45%, #4be3af 100%);
+  box-shadow:
+    inset 0 1px 1px rgb(255 255 255 / 48%),
+    0 0 8px rgb(124 247 200 / 36%);
+  animation: cell-born 160ms ease-out;
+}
+
+.life-cell.is-alive:hover {
+  background: #c3ffea;
+  box-shadow: 0 0 12px rgb(124 247 200 / 58%);
+}
+
+.life-cell:focus-visible {
+  z-index: 2;
+  outline: 2px solid var(--blue);
+  outline-offset: 1px;
+  transform: scale(1.18);
+}
+
+.rule-legend {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 1px;
+  border-top: 1px solid var(--border);
+  background: var(--border);
+}
+
+.rule-legend > div {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 10px;
+  align-items: center;
+  min-height: 62px;
+  padding: 12px 16px;
+  background: var(--surface);
+}
+
+.legend-number {
+  display: grid;
+  min-width: 31px;
+  height: 31px;
+  padding: 0 5px;
+  border: 1px solid rgb(124 247 200 / 25%);
+  border-radius: 9px;
+  background: rgb(124 247 200 / 8%);
+  color: var(--mint);
+  font: 750 11px/1 ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  place-items: center;
+}
+
+.legend-number.muted-number {
+  min-width: 61px;
+  border-color: var(--border);
+  background: var(--surface-soft);
+  color: var(--muted-bright);
+}
+
+.rule-legend p {
+  margin: 0;
+  color: var(--muted);
+  font-size: 9px;
+  line-height: 1.4;
+}
+
+@keyframes cell-born {
+  from {
+    opacity: 0.42;
+    transform: scale(0.55);
+  }
+
+  to {
+    opacity: 1;
+    transform: scale(1);
+  }
+}
+
+@keyframes breathe {
+  50% {
+    box-shadow: 0 0 0 6px rgb(124 247 200 / 4%), 0 0 22px rgb(124 247 200 / 75%);
+  }
+}
+
+@media (max-width: 1040px) {
+  .workspace {
+    grid-template-columns: 1fr;
+  }
+
+  .preset-panel {
+    position: static;
+  }
+
+  .preset-list {
+    grid-template-columns: repeat(2, 1fr);
+  }
+
+  .tip-card {
+    max-width: 470px;
+  }
+}
+
+@media (max-width: 760px) {
+  .life-app {
+    padding: 22px 12px 30px;
+  }
+
+  .hero-copy {
+    display: block;
+  }
+
+  .hero-copy p {
+    margin-top: 16px;
+  }
+
+  .preset-panel,
+  .simulation-panel {
+    border-radius: 16px;
+  }
+
+  .control-bar {
+    grid-template-columns: 1fr auto;
+  }
+
+  .primary-actions {
+    grid-column: 1;
+  }
+
+  .secondary-actions {
+    grid-column: 2;
+    justify-self: end;
+  }
+
+  .speed-control {
+    grid-column: 1 / -1;
+    justify-self: start;
+  }
+
+  .status-strip {
+    grid-template-columns: repeat(2, 1fr);
+    gap: 14px 0;
+    padding-block: 15px;
+  }
+
+  .run-state {
+    justify-self: start;
+  }
+
+  .rule-legend {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (max-width: 520px) {
+  .preset-list {
+    grid-template-columns: 1fr;
+  }
+
+  .control-bar {
+    display: flex;
+    flex-wrap: wrap;
+  }
+
+  .primary-actions,
+  .secondary-actions {
+    width: 100%;
+  }
+
+  .primary-actions button,
+  .secondary-actions button {
+    flex: 1;
+  }
+
+  .coordinate-hint {
+    display: none;
+  }
+
+  .board-frame {
+    padding: 8px;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    scroll-behavior: auto !important;
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+  }
+}

--- a/scripts/coverage-audit.mjs
+++ b/scripts/coverage-audit.mjs
@@ -14,6 +14,7 @@ const externalCoverage = new Map([
   ["./samples/annotated-js", verifier("scripts/verify-js-samples.mjs", "annotated-js")],
   ["./samples/browser-bench", verifier("bench/driver/bench.mjs", "01_run1k")],
   ["./samples/browser-counter", verifier("scripts/verify-browser.mjs", "function verifyCounter(")],
+  ["./samples/browser-game-of-life", verifier("scripts/verify-browser.mjs", "function verifyGameOfLife(")],
   ["./samples/browser-tests", verifier("scripts/verify-browser.mjs", "function verifyBrowserTests(")],
   ["./samples/browser-todo", verifier("scripts/verify-browser.mjs", "function verifyTodo(")],
   ["./samples/server-components-client", verifier("scripts/verify-browser.mjs", "function verifyServerComponents(")],

--- a/scripts/verify-browser.mjs
+++ b/scripts/verify-browser.mjs
@@ -12,6 +12,7 @@ const browser = await chromium.launch({
 try {
   await verifyBrowserTests();
   await verifyCounter();
+  await verifyGameOfLife();
   await verifyTodo();
   if (serverComponentsUrl) {
     await verifyServerComponents();
@@ -61,6 +62,55 @@ async function verifyCounter() {
   await page.close();
 }
 
+async function verifyGameOfLife() {
+  const page = await newPage("browser-game-of-life");
+  await page.goto(`${baseUrl}/samples/browser-game-of-life/web/index.html`, { waitUntil: "networkidle" });
+  await page.locator('[data-testid="life-grid"]').waitFor({ timeout: 5_000 });
+  await page.getByText("72 × 48 universe", { exact: true }).waitFor({ timeout: 5_000 });
+
+  const cellCount = await page.locator(".life-cell").count();
+  if (cellCount !== 72 * 48) {
+    throw new Error(`Game of Life rendered ${cellCount} cells instead of 3456`);
+  }
+  const scrollPosition = await page.locator(".board-scroll").evaluate((viewport) => ({
+    actual: viewport.scrollLeft,
+    centered: (viewport.scrollWidth - viewport.clientWidth) / 2,
+  }));
+  if (Math.abs(scrollPosition.actual - scrollPosition.centered) > 2) {
+    throw new Error(`Game of Life board was not centered: ${JSON.stringify(scrollPosition)}`);
+  }
+
+  await page.locator('[data-testid="preset-glider"]').click();
+  await waitForText(page, "population-value", "5");
+  await waitForText(page, "generation-value", "0");
+
+  await page.locator('[data-testid="step"]').click();
+  await waitForText(page, "generation-value", "1");
+
+  const editableCell = page.locator('[data-testid="cell-0-0"]');
+  if (await editableCell.getAttribute("aria-pressed") !== "false") {
+    throw new Error("Expected the corner cell to start dead");
+  }
+  await editableCell.click();
+  if (await editableCell.getAttribute("aria-pressed") !== "true") {
+    throw new Error("Clicking a dead cell did not make it alive");
+  }
+
+  await page.locator('[data-testid="preset-beacon"]').click();
+  await page.locator('[data-testid="speed-fast"]').click();
+  await page.locator('[data-testid="toggle-running"]').click();
+  await page.waitForFunction(
+    () => Number(document.querySelector('[data-testid="generation-value"]')?.textContent ?? "0") >= 2,
+    undefined,
+    { timeout: 5_000 },
+  );
+  await page.locator('[data-testid="toggle-running"]').click();
+  await page.getByText("Paused", { exact: true }).waitFor({ timeout: 5_000 });
+
+  assertNoPageErrors(page, "browser-game-of-life");
+  await page.close();
+}
+
 async function verifyTodo() {
   const page = await newPage("browser-todo");
   await page.goto(`${baseUrl}/samples/browser-todo/web/index.html`, { waitUntil: "networkidle" });
@@ -76,6 +126,14 @@ async function verifyTodo() {
   await page.getByText("Ship browser renderer").waitFor({ timeout: 5_000 });
   assertNoPageErrors(page, "browser-todo");
   await page.close();
+}
+
+async function waitForText(page, testTag, expected) {
+  await page.waitForFunction(
+    ({ testTag, expected }) => document.querySelector(`[data-testid="${testTag}"]`)?.textContent === expected,
+    { testTag, expected },
+    { timeout: 5_000 },
+  );
 }
 
 async function verifyServerComponents() {


### PR DESCRIPTION
## Summary

- add an interactive Conway's Game of Life browser demo built with Kinetica
- provide a finite 72 × 48 editable universe with run, pause, step, speed, randomize, and clear controls
- include Glider, Lightweight Spaceship, Beacon, and Pulsar presets
- add deterministic model tests and browser end-to-end coverage
- wire the sample into the project and CI JS build/test flow

## Why

This adds a polished, stateful demo that exercises Kinetica's keyed rendering, event handling, derived state, and lifecycle-bound async effects.

## Validation

- `./kotlin publish mavenLocal -m kinetica-compiler`
- `./kotlin build -m browser-game-of-life`
- `node build/tasks/_browser-game-of-life_linkJsTest/browser-game-of-life_test.mjs`
- full `scripts/verify-browser.mjs` Playwright suite
- `node --check` for updated verifier scripts
- `git diff --check`
